### PR TITLE
Added WayStation to the list of remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | HubSpot | CRM | `https://app.hubspot.com/mcp/v1/http` | API Key | [HubSpot](https://hubspot.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | API Key | [Stripe](https://stripe.com) |
 | Needle | RAG-as-a-service | `https://mcp.needle-ai.com/mcp` | API Key | [Needle](https://needle-ai.com) |
+| WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 
 ## How to use remote MCP servers?


### PR DESCRIPTION
Please consider adding WayStation to the list of remote MCP servers. WayStation MCP seamlessly connects Claude (and other clients) to a broad range of productivity tools, including Notion, Monday, AirTable, etc.

A few notes:
- WayStation MCP supports both Streamable HTTPS and SSE transports
- The default endpoint at https://waystation.ai/mcp does transport negotiation and authorization if necessary
- WayStation also provides preauthenticated individual endpoints like https://waystation.ai/mcp/Iddq66dIdkfARDNb3K. Any registered user can get one at https://waystation.ai/connect/mcp-server/guide
- The server was tested with Claude, Cursor, Cline, WindSurf, and MCP-remote

Thanks for consideration!