### PR TITLE
Add Mercado Pago's official MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
+| Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 
 ## How to use remote MCP servers?
 


### PR DESCRIPTION
## Description
Add official Mercado Pago MCP Server (http://mcp.mercadopago.com/) on Official Integrations section. 

## Server Details
Add new official MCP Server for Mercado Pago, to enhance developer experience integrating Mercado Pago solutions.
Server is hosted remotely by Mercadolibre supporting new Streamable HTTP Transport.
Details on how to connect to the server and example use cases are provided in [Mercado Pago's MCP Server doc site](http://mcp.mercadopago.com/).

## Motivation and Context
Provide official MCP Server for Mercado Pago to enhance developers experience integrating with this platform.

## How Has This Been Tested?
Integration with the server was tested from several clients, including: Cursor, Windsurf, Cline and Claude Desktop.
