### PR TITLE
Add Mercado Libre's official MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
+| Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | monday.com | Project Management,CRM,WorkOS,Service | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |


### PR DESCRIPTION
## Description
Add official Mercado Libre MCP Server (http://mcp.mercadolibre.com/).

## Server Details
Add new official MCP Server for Mercado Libre, to enhance developer experience integrating with Mercado Libre solutions.
Server is hosted remotely by Mercadolibre supporting new Streamable HTTP Transport.
Details on how to connect to the server and example use cases are provided in [Mercado Libre's MCP Server doc site](http://mcp.mercadolibre.com/).

## Motivation and Context
Provide official MCP Server for Mercado Libre to enhance developers experience integrating with this platform.

## How Has This Been Tested?
Integration with the server was tested from several clients, including: Cursor, Windsurf, Cline and Claude Desktop.
