### PR TITLE
feat: Add Carbon Voice official ⭐ MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Audioscrape | RAG-as-a-Service | https://mcp.audioscrape.com | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlasian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 | [Atlassian](https://atlassian.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
+| Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
MCP Server official implementation developed by the Carbon Voice team to enable LLMs to access tools for [Carbon Voice Platform](https://getcarbon.app).

## Motivation and Context
Enable AI assistants and LLMs to seamlessly integrate with Carbon Voice's voice messaging platform, providing comprehensive access to voice conversations, message management, and AI-powered content processing capabilities.

## How Has This Been Tested?
- [x] Each tool on the MCP server has been manually tested within:
  - [x] Claude Desktop
  - [x] Claude AI
  - [x] Cursor
