### PR TITLE
Update Zenable details

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Wix | CMS | `https://mcp.wix.com/sse` | OAuth2.1 | [Wix](https://wix.com) |
 | Simplescraper | Web Scraping | `https://mcp.simplescraper.io/mcp` | OAuth2.1 | [Simplescraper](https://simplescraper.io) |
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
-| Zenable | Security | `https://mcp.www.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |
+| Zenable | Security | `https://mcp.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |
 | Zine | Memory | `https://www.zine.ai/mcp` | OAuth2.1 | [Zine](https://www.zine.ai/) |
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |


### PR DESCRIPTION
We moved our server from `mcp.www.zenable.app` to `mcp.zenable.app`

[Here](https://docs.zenable.io/integrations/zenable-mcp/commands#mcp-server-configuration) is evidence of the move

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the Zenable MCP server URL from `mcp.www.zenable.app` to `mcp.zenable.app` in the README.md file. The change reflects Zenable's server migration as documented in their official documentation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->