### PR TITLE
Add AWS Knowledge entry to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
+| AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |


### PR DESCRIPTION
Official MCP server from AWS to access docs around AWS resources.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a single new entry to the README's MCP server list for AWS Knowledge, an official AWS MCP server that provides access to documentation about AWS resources. The server is categorized under Software Development, uses an open authentication scheme, and is accessible at `https://knowledge-mcp.global.api.aws`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->