### PR TITLE
Adding Metro-MCP to the server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
-| Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://www.anuragd.me/) |
+| Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 


### PR DESCRIPTION
This PR adds Metro-MCP to the readme file. The Metro-MCP server currently supports Washington, D.C.'s Metro system (WMATA) and New York City's transit system (MTA). 

Supporting other cities is on the roadmap, and I am working on adding more.  It supports OAuth via GitHub. 

Thanks, 
[Anurag Dhungana](https://www.anuragd.me/)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Metro-MCP, a transit information server supporting Washington D.C.'s WMATA and New York City's MTA systems, to the remote MCP servers list in the README. The server uses OAuth2.1 authentication via GitHub and is hosted at `https://metro-mcp.anuragd.me/sse`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->