### PR TITLE
Add MTA NYC Transit MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
+| MTA NYC Transit | Transportation | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo.nyc](https://subwayinfo.nyc) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 


### PR DESCRIPTION
Adding SubwayInfo.nyc - a production MCP server for real-time NYC subway data.

**Features:**
- Real-time train arrivals for all 496 NYC subway stations
- Service alerts and delays
- Trip planning with transfer optimization
- One-click Claude Desktop installer (.mcpb)
- Fully deployed on Cloudflare Workers

**Live at:** https://subwayinfo.nyc
**GitHub:** https://github.com/ckorhonen/mta-mcp
**Stats:** https://subwayinfo.nyc/stats

The server uses HTTP Streamable transport and is production-ready with:
- Type-safe protobuf schemas
- MTA GTFS-RT integration
- Global edge deployment
- Open access (no auth required)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds **SubwayInfo.nyc** to the list of available remote MCP servers, providing real-time NYC subway data including train arrivals, service alerts, and trip planning. The server is production-ready, deployed on Cloudflare Workers, and uses HTTP Streamable transport with open access requiring no authentication.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->