### PR TITLE
Add BGPT — scientific paper search remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
+| BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |


### PR DESCRIPTION
## Summary

Adds [BGPT](https://bgpt.pro/mcp) to the remote MCP server list.

BGPT is a hosted MCP server for searching scientific papers with structured experimental data extracted from full-text studies. Each result returns 25+ fields including methods, results, sample sizes, limitations, and quality scores.

## Details

- **SSE Endpoint**: `https://bgpt.pro/mcp/sse`
- **Authentication**: Open (free tier, 50 searches) / API Key (pay-as-you-go at $0.01/result)
- **Category**: Scientific Research
- **GitHub**: https://github.com/connerlambden/bgpt-mcp
- **Official MCP Registry**: Listed as `io.github.connerlambden/bgpt-mcp`

## Changes

- Added BGPT entry to the Remote MCP Server List table, alphabetically between AWS Knowledge and Box


Made with [Cursor](https://cursor.com)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds BGPT, a scientific paper search service, to the remote MCP server list in the README. BGPT provides structured experimental data extracted from full-text studies with 25+ fields including methods, results, sample sizes, and quality scores. The service offers both a free tier (50 searches) and pay-as-you-go pricing at $0.01 per result. The entry is inserted alphabetically between AWS Knowledge and Box in the existing table.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->