### PR TITLE
Add LimitGuard Trust Intelligence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Google GKE | Developer Tools | `https://container.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/kubernetes-engine/docs/reference/mcp) |
 | Google Maps | Mapping | `https://mapstools.googleapis.com/mcp` | API Key | [Google](https://developers.google.com/maps/ai/grounding-lite/reference/mcp) |
 | HubSpot | CRM | `https://app.hubspot.com/mcp/v1/http` | API Key | [HubSpot](https://hubspot.com) |
+| LimitGuard | Security | `https://api.limitguard.ai/mcp` | API Key | [LimitGuard](https://limitguard.ai) |
 | Needle | RAG-as-a-service | `https://mcp.needle-ai.com/mcp` | API Key | [Needle](https://needle-ai.com) |
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |


### PR DESCRIPTION
Adds LimitGuard Trust Intelligence — entity verification, sanctions screening, and trust scoring remote MCP server.

## Server Details

| Field | Value |
|-------|-------|
| Name | LimitGuard Trust Intelligence |
| Category | Security |
| URL | `https://api.limitguard.ai/mcp` |
| Authentication | x402 Micropayment (USDC, no API key needed) |
| Maintainer | [LimitGuard](https://limitguard.ai) |

## Quality Criteria

- **Official Support**: Maintained by Ambulatio Consulting B.V.
- **Production Ready**: Live at api.limitguard.ai with 1194+ tests
- **Active Maintenance**: Regular updates, latest commit today
- **Security**: x402 payment auth, OWASP-audited, EU data residency
- **Reliability**: 200ms average response, health monitoring at status.limitguard.ai
- **Community**: Listed on official MCP Registry (ai.limitguard.api/trust-intelligence)

## Tools

| Tool | Description | Price |
|------|-------------|-------|
| check_entity | Full entity trust check — KVK/CBE registry, sanctions, domain, risk scoring | $0.85 |
| check_agent | Verify AI agent identity and reputation | $0.10 |
| trust_score | Entity trust score (0-100) with cluster assignment | $0.10 |
| verify_wallet | Blockchain wallet address verification and risk flags | $0.10 |
| risk_score | Quick risk score for entity name + country pair | $0.65 |