### PR TITLE
Add EVC Team Relay MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
+| EVC Team Relay MCP | Knowledge Management | `https://evc-team-relay-mcp--entire-vc.run.tools` | Open | [Entire VC](https://github.com/entire-vc/evc-team-relay-mcp) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |


### PR DESCRIPTION
Add [EVC Team Relay MCP](https://github.com/entire-vc/evc-team-relay-mcp) - an Obsidian vault knowledge management MCP server.

- **Category:** Knowledge Management
- **Remote URL:** `https://evc-team-relay-mcp--entire-vc.run.tools` (Smithery-deployed)
- **Auth:** Open
- **Maintainer:** [Entire VC](https://entire.vc)
- **Tools:** list_notes, read_note, write_note, search_notes, list_folders

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the **EVC Team Relay MCP** server to the list of available remote MCP servers in the README. The server provides knowledge management capabilities for Obsidian vault integration, offering tools like `list_notes`, `read_note`, `write_note`, `search_notes`, and `list_folders`. It's deployed via Smithery with open authentication and maintained by Entire VC.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

Homepage: https://entire.vc/team-relay/ai/
