### PR TITLE
Add Ink MCP — application deployment platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |
+| Ink | Software Development | `https://mcp.ml.ink/mcp` | OAuth2.1 | [ml.ink](https://ml.ink) |
 | Invidio | Video Platform | `https://mcp.invideo.io/sse` | OAuth2.1 | [Invidio](https://invideo.io/) |
 | Jam | Software Development | `https://mcp.jam.dev/mcp` | OAuth2.1 | [Jam.dev](https://jam.dev/) |
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |


### PR DESCRIPTION
Ink MCP is a remote MCP server for deploying and managing applications. OAuth 2.1 auth, streamable HTTP transport. https://github.com/mldotink/mcp

- **Name**: Ink
- **Category**: Software Development
- **URL**: `https://mcp.ml.ink/mcp`
- **Auth**: OAuth2.1
- **Maintainer**: [ml.ink](https://ml.ink)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Ink MCP to the list of remote MCP servers in the README. Ink is an application deployment platform that uses OAuth 2.1 authentication and is categorized under Software Development. The change is a single line addition to maintain the alphabetically sorted table of MCP servers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->