### PR TITLE
Add Omnis Venture Intelligence remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
+| Omnis Venture Intelligence | Market Intelligence | `https://www.bamboosnow.co/api/v1/mcp` | API Key | [BambooSnow](https://www.bamboosnow.co/venture-intelligence-mcp-server) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
Adds Omnis, a remote venture-intelligence MCP server for startup discovery, company scoring, monitoring, and private workspace automation.\n\nPublic MCP endpoint: https://www.bamboosnow.co/api/v1/mcp\nDocs: https://www.bamboosnow.co/venture-intelligence-mcp-server\nInstant activation: POST https://www.bamboosnow.co/api/v1/agents/pay

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Omnis Venture Intelligence as a new remote MCP server to the registry. The server provides venture intelligence capabilities including startup discovery, company scoring, monitoring, and workspace automation through an API key-authenticated endpoint at `https://www.bamboosnow.co/api/v1/mcp`. The change is a single-line addition to the README table that lists available remote MCP servers in the Market Intelligence category.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->