### PR TITLE
Add Waggle remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |
+| Waggle | A2A Agent Discovery | `https://api.waggle.zone/mcp` | API Key | [Waggle](https://waggle.zone) |
 | Dodo Payments | Payments | `https://mcp.dodopayments.com/sse` | API Key | [Dodo Payments](https://dodopayments.com) |
 | Polar Signals | Software Development | `https://api.polarsignals.com/api/mcp/` | API Key | [Polar Signals](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) |
 | Manifold | Forecasting | `https://api.manifold.markets/v0/mcp` | Open | [Manifold](https://manifold.markets) |


### PR DESCRIPTION
## What is Waggle?

[Waggle](https://waggle.zone) is a search engine for A2A (Agent-to-Agent) protocol agents. It indexes agents that implement Google's [A2A protocol](https://github.com/google/a2a) and provides semantic search, direct invocation, async polling, and community ratings for A2A agents.

## Server Details

- **URL**: `https://api.waggle.zone/mcp`
- **Transport**: Streamable HTTP
- **Auth**: API Key (`X-Api-Key` header) — free tier available at [waggle.zone](https://waggle.zone)
- **Published** on the [official MCP Registry](https://registry.modelcontextprotocol.io) as `zone.waggle/waggle`

## 7 MCP Tools

| Tool | Description |
|------|-------------|
| `search` | Semantic search for A2A agents by capability |
| `invoke` | Send a task to an agent and get results |
| `poll` | Check status of async agent tasks |
| `info` | Get detailed info on a specific agent |
| `register` | Submit a new agent URL for indexing |
| `check_usage` | View API quota and usage |
| `rate_transaction` | Rate an agent interaction |

## Quality Criteria

- **Official**: Maintained by the Waggle team
- **Production Ready**: Live at waggle.zone with active users
- **Active Maintenance**: Regularly updated
- **Security**: API key auth, SSRF prevention, rate limiting
- **Reliability**: Health-monitored with uptime tracking