### PR TITLE
Add Xquik X/Twitter MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | WebZum | Website Hosting | `https://webzum.com/api/mcp` | Open | [WebZum](https://webzum.com) |
 | Simplescraper | Web Scraping | `https://mcp.simplescraper.io/mcp` | OAuth2.1 | [Simplescraper](https://simplescraper.io) |
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
+| Xquik | Social Media | `https://xquik.com/mcp` | API Key | [Xquik](https://xquik.com) |
 | Zenable | Security | `https://mcp.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |
 | Zine | Memory | `https://www.zine.ai/mcp` | OAuth2.1 | [Zine](https://www.zine.ai/) |
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |


### PR DESCRIPTION
Adds [Xquik](https://xquik.com) remote MCP server to the list.

- **URL:** `https://xquik.com/mcp`
- **Transport:** StreamableHTTP
- **Auth:** API Key
- **Category:** Social Media

Xquik provides real-time X (Twitter) data via MCP with 76 API endpoints covering tweet search, user lookup, follower extraction, 20 bulk tools, account monitoring, giveaway draws, and write actions.

- [GitHub](https://github.com/Xquik-dev/x-twitter-scraper)
- [API Docs](https://docs.xquik.com)
- [MCP Guide](https://docs.xquik.com/mcp/overview)

Disclosure: I am the developer of Xquik.