### PR TITLE
Add Frihet — AI-native business management (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| Frihet | Business Management | `https://mcp.frihet.io/mcp` | OAuth2.1 | [Frihet](https://www.frihet.io) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
## New Remote MCP Server: Frihet

Adds [Frihet](https://www.frihet.io) to the remote MCP server list.

### Server Details

| Field | Value |
|-------|-------|
| **Name** | Frihet |
| **Category** | Business Management |
| **Remote URL** | `https://mcp.frihet.io/mcp` |
| **Transport** | Streamable HTTP (Cloudflare Workers) |
| **Authentication** | OAuth 2.1 + PKCE |
| **Website** | https://www.frihet.io |
| **npm** | [@frihet/mcp-server](https://www.npmjs.com/package/@frihet/mcp-server) |
| **GitHub** | [Frihet-io/frihet-mcp](https://github.com/Frihet-io/frihet-mcp) |
| **License** | MIT |

### What it does

AI-native business management platform. 31 tools for invoicing, expenses, clients, products, quotes, tax compliance (VeriFactu), and webhooks. Multi-currency (40 currencies), OCR, and Stripe Connect.

### Checklist

- [x] Remote MCP server accessible over the internet
- [x] OAuth 2.1 authentication with PKCE
- [x] Production ready and actively maintained
- [x] Official server maintained by the underlying company
- [x] Entry placed in alphabetical order in the table
- [x] Format matches existing entries