### PR TITLE
Add DexPaprika to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
+| DexPaprika | Crypto | `https://mcp.dexpaprika.com/sse` | Open | [DexPaprika](https://dexpaprika.com) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
+| DexPaprika | Crypto | `https://mcp.dexpaprika.com/sse` | Open | [CoinPaprika](https://coinpaprika.com) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
@@ -83,7 +84,6 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
-| DexPaprika | Crypto | `https://mcp.dexpaprika.com/sse` | Open | [DexPaprika](https://dexpaprika.com) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |


### PR DESCRIPTION
Adds DexPaprika, a hosted remote MCP server for on-chain DEX data.

- **Category:** Crypto
- **URL:** `https://mcp.dexpaprika.com/sse`
- **Authentication:** Open, no key or registration needed to start
- **Transport:** SSE, Streamable HTTP, JSON-RPC
- **Coverage:** 36 chains, 33M+ tokens, 36M+ pools, 230+ DEXes
- **Maintainer:** [CoinPaprika](https://coinpaprika.com), which runs DexPaprika

The free tier is metered and rate limited. Current limits: https://dexpaprika.com/api/pricing
