### PR TITLE
Add BCB BR MCP — Brazilian Central Bank economic data

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
+| BCB BR MCP | Data Analysis | `https://bcb.sidneybissoli.workers.dev` | Open | [Sidney Bissoli](https://github.com/SidneyBissoli) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |


### PR DESCRIPTION
## Summary

- Adds **BCB BR MCP** to the Remote MCP Servers list under **Data Analysis**.
- Brazilian Central Bank (BCB) economic data — 18,000+ time series including Selic, IPCA, exchange rates, GDP, and 150+ curated indicators via the SGS/BCB public API.
- Remote endpoint via Cloudflare Workers: `https://bcb.sidneybissoli.workers.dev`
- Open access, no API key required.

## Quality Criteria

- **Production Ready**: Stable, deployed on Cloudflare Workers with auto-retry and 30s timeouts
- **Active Maintenance**: Regular releases (v1.0.0 → v1.2.1), active GitHub repository
- **Security**: Open access to public government data (no sensitive data involved)
- **Reliability**: Hosted on Cloudflare's global edge network

## Links

- GitHub: https://github.com/SidneyBissoli/bcb-br-mcp
- npm: https://www.npmjs.com/package/bcb-br-mcp
- Glama (AAA score): https://glama.ai/mcp/servers/SidneyBissoli/bcb-br-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)