### PR TITLE
Add APIbase remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| [APIbase](https://apibase.pro) | Aggregator | `https://apibase.pro/mcp` | API Key / x402 | [whiteknightonhorse](https://github.com/whiteknightonhorse/APIbase) | Multi-provider API gateway: travel, finance, crypto, weather tools |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adding [APIbase](https://apibase.pro) — a unified MCP gateway that serves 56+ real-time API tools to AI agents across travel, prediction markets, crypto, and weather.

APIbase is an open-source, production MCP server with x402 micropayments, auto-registration, and Streamable HTTP transport.