### PR TITLE
Add Global Chat MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | OpenZeppelin Stylus Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/stylus/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |
 | LLM Text | Data Analysis | `https://mcp.llmtxt.dev/sse` | Open | [LLM Text](https://llmtxt.dev) |
 | GitMCP | Software Development | `https://gitmcp.io/docs` | Open | [GitMCP](https://gitmcp.io) |
+| Global Chat | MCP Directory | `https://global-chat.io/api/mcp` | Open | [Global Chat](https://global-chat.io) |
 | Close | CRM | `https://mcp.close.com/mcp` | API Key | [Close](https://help.close.com/docs/mcp-server) |
 | Google Big Query | Data Analysis | `https://bigquery.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/bigquery/docs/reference/mcp) |
 | Google Compute Engine	| Developer Tools | `https://compute.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/compute/docs/reference/mcp) |


### PR DESCRIPTION
## Add Global Chat MCP Server

Adds [Global Chat](https://global-chat.io) to the Remote MCP Server List.

### Server Details

| Field | Value |
|-------|-------|
| **Name** | Global Chat |
| **Category** | MCP Directory |
| **URL** | `https://global-chat.io/api/mcp` |
| **Authentication** | Open |
| **Maintainer** | [Global Chat](https://global-chat.io) |

### Why it meets the quality criteria

- **Official Support**: Maintained by the Global Chat team. Open source at [github.com/pumanitro/global-chat](https://github.com/pumanitro/global-chat)
- **Production Ready**: Live HTTP endpoint serving MCP protocol at `https://global-chat.io/api/mcp`
- **Active Maintenance**: Regular updates, published on npm as [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)
- **Security**: Open access endpoint, no authentication required
- **Reliability**: Hosted on Vercel with global CDN

### What it does

Global Chat is a cross-protocol AI agent discovery platform. The MCP server provides tools to search 18K+ MCP servers across 6+ registries, discover AI agents across MCP, A2A, and agents.txt protocols, and access a free agents.txt validator.