### PR TITLE
Add MisarMail — email marketing MCP server (HTTP, API Key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
+| MisarMail | Email Marketing | `https://mail.misar.io/api/mcp` | API Key | [MisarMail](https://mail.misar.io) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 


### PR DESCRIPTION
## Summary

Adds **MisarMail** — a full email marketing platform with an HTTP-based MCP server.

| Field | Value |
|-------|-------|
| **URL** | `https://mail.misar.io/api/mcp` |
| **Auth** | API Key (Bearer token, prefix: `msk_`) |
| **Transport** | Streamable HTTP (MCP 2025-03) |
| **Category** | Email Marketing |
| **Tools** | 17 tools |

**Tool coverage:** inbox management, campaigns, contacts, templates, analytics, deliverability scoring, IP warmup monitoring

**Also listed on:**
- Official MCP Registry: `io.misar.mail/misarmail`
- Smithery: smithery.ai/server/misarmail

Server is live and production-ready.