### PR TITLE
Add ToolRouter — unified MCP gateway for 80+ AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
+| ToolRouter | AI Tools | `https://api.toolrouter.com/mcp` | OAuth2.1 | [ToolRouter](https://toolrouter.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |


### PR DESCRIPTION
## ToolRouter

Adding [ToolRouter](https://toolrouter.com) to the remote MCP server list.

**Details:**
- **Name:** ToolRouter
- **Category:** AI Tools
- **URL:** `https://api.toolrouter.com/mcp`
- **Authentication:** OAuth 2.1 (with dynamic client registration)
- **Maintainer:** [ToolRouter](https://toolrouter.com)

**What it does:**
ToolRouter is a unified MCP gateway — one connection gives AI agents access to 80+ tools across SEO, screenshots, web search, image generation, security scanning, and more. Usage-based billing, no per-tool setup.

**Authentication:**
Full OAuth 2.1 support with dynamic client registration, following the MCP spec. Clients like Claude Desktop, Cursor, and ChatGPT can connect using just the server URL.

**Clients supported:**
Claude, ChatGPT, Copilot, Cursor, Windsurf, and any MCP-compatible client.