### PR TITLE
Add SheetsData MCP — electronic component datasheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
+| SheetsData | Electronics | `https://mcp.sheetsdata.com/mcp` | API Key | [Octoco](https://github.com/octoco-ltd/sheetsdata-mcp) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |


### PR DESCRIPTION
## Summary

- Adds [SheetsData](https://github.com/octoco-ltd/sheetsdata-mcp) to the remote MCP server list
- SheetsData gives AI agents instant access to electronic component datasheets — specs, pinouts, package info — extracted from manufacturer PDFs. No uploads needed.
- Remote Streamable HTTP server at `https://mcp.sheetsdata.com/mcp`, authenticated via API Key (Bearer token)
- Maintained by [Octoco](https://github.com/octoco-ltd)