### PR TITLE
Add tickadoo — bookable experiences MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
+| tickadoo | Travel & Experiences | `https://mcp.tickadoo.com/mcp` | Open | [tickadoo](https://mcp.tickadoo.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |


### PR DESCRIPTION
## tickadoo MCP Server

**Category:** Travel & Experiences
**URL:** `https://mcp.tickadoo.com/mcp`
**Authentication:** Open (no API key required)
**Maintainer:** [tickadoo](https://mcp.tickadoo.com)

Search and discover 7,700+ bookable experiences (theatre, tours, attractions, live shows) across 700+ cities. 4 MCP tools, JSON output, 40+ languages.

- ✅ Official, production-ready, actively maintained
- ✅ Listed on Official MCP Registry, Smithery, Glama
- ✅ Health endpoint, LRU caching, input validation
- ✅ GitHub: https://github.com/tickadoo/tickadoo-mcp