### PR TITLE
Add podcast/newsletter/recipe content commerce MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| Newsletter Commerce MCP | Content Commerce | `https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp` | Open / x402 | [Since Today](https://sincetoday.com) |
+| Podcast Commerce MCP | Content Commerce | `https://podcast-commerce-mcp.sincetoday.workers.dev/mcp` | Open / x402 | [Since Today](https://sincetoday.com) |
+| Recipe Commerce MCP | Content Commerce | `https://recipe-commerce-mcp.sincetoday.workers.dev/mcp` | Open / x402 | [Since Today](https://sincetoday.com) |
 
 
 # Remote MCP Installation Guide
@@ -366,3 +369,4 @@ Join the MCP community to stay updated and connect with other developers:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+


### PR DESCRIPTION
## Summary

Adds three remote MCP servers focused on content commerce intelligence:

- **Podcast Commerce MCP** (`https://podcast-commerce-mcp.sincetoday.workers.dev/mcp`) — Extract affiliate product mentions from podcast transcripts, analyze sponsors, track trends across episodes, compare products across shows, generate shoppable show notes. Category: Content Commerce.
- **Newsletter Commerce MCP** (`https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp`) — Extract products and affiliate signals from newsletters, analyze sponsor patterns, track affiliate performance. Category: Content Commerce.
- **Recipe Commerce MCP** (`https://recipe-commerce-mcp.sincetoday.workers.dev/mcp`) — Extract ingredient brands from recipe content, match to affiliate products, surface monetization opportunities. Category: Content Commerce.

## Details

- **Infrastructure**: Cloudflare Workers (global edge, low latency)
- **Auth**: Free tier 200 calls/day (Open, no registration), paid tier $0.01/call via x402 micropayment protocol
- **Quality**: F1=100% on test suites, OWASP MCP security compliant, CI/CD via GitHub Actions
- **Maintained by**: [Since Today](https://sincetoday.com) — active development
- **GitHub org**: [teamsincetoday](https://github.com/teamsincetoday)

These are the only MCP servers focused on affiliate/commerce extraction from content formats (podcasts, newsletters, recipes).