### PR TITLE
Add Frihet ERP — remote MCP server with 52 business tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| Frihet ERP | Business Management | `https://mcp.frihet.io` | OAuth2.1 | [Frihet](https://frihet.io) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds **Frihet ERP** to the Remote MCP Server List under the **Business Management** category
- Remote endpoint: `https://mcp.frihet.io` with OAuth 2.1 authentication
- 52 tools covering invoicing, expenses, clients, products, quotes, full double-entry accounting, tax compliance for 139 countries, fiscal autopilot, e-invoicing (EN16931), and open banking integration via Tink (6,000+ banks)
- Also available locally via `npx @frihet/mcp-server` and on npm as `@frihet/mcp-server`
- GitHub: https://github.com/Frihet-io/frihet-mcp

## Why it qualifies

Frihet has a production remote MCP endpoint at `mcp.frihet.io` with OAuth 2.1 authentication, meeting all quality criteria: official maintainer (Frihet team), production-ready and stable, actively maintained, OAuth 2.0 security, and a growing user community.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)