### PR TITLE
Add Ooty - SEO/Marketing remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Google GKE | Developer Tools | `https://container.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/kubernetes-engine/docs/reference/mcp) |
 | Google Maps | Mapping | `https://mapstools.googleapis.com/mcp` | API Key | [Google](https://developers.google.com/maps/ai/grounding-lite/reference/mcp) |
 | HubSpot | CRM | `https://app.hubspot.com/mcp/v1/http` | API Key | [HubSpot](https://hubspot.com) |
+| Ooty | SEO/Marketing | `https://ooty.io/api/mcp/seo` | API Key | [Ooty](https://ooty.io) |
 | Needle | RAG-as-a-service | `https://mcp.needle-ai.com/mcp` | API Key | [Needle](https://needle-ai.com) |
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
+| Ooty | SEO & Marketing | `https://ooty.io/api/mcp/seo` | API Key | [Ooty](https://ooty.io) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Parallel Search MCP | Web Search | `https://search-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
## What is Ooty?

[Ooty](https://ooty.io) provides remote MCP servers for SEO, analytics, video, commerce, social, and ads — 200+ tools accessible from ChatGPT, Gemini, Claude, and any MCP-compatible client.

- **Remote endpoint**: `https://ooty.io/api/mcp/seo` (and `/analytics`, `/video`, `/commerce`, `/social`, `/ads`)
- **Authentication**: API Key (Bearer token)
- **Production-ready**: Deployed on Vercel, actively maintained
- **200+ tools** across 6 product domains

## Changes

Added Ooty to the Remote MCP Server List table in alphabetical order, matching the existing format.