### PR TITLE
Add ContextWire - Free search API MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |
 | Context Awesome | Specialised Dataset | `https://www.context-awesome.com/api/mcp` | Open | [Context Awesome](https://www.context-awesome.com/) |
+| ContextWire | Search | `https://contextwire.dev/mcp` | Open | [ContextWire](https://contextwire.dev) |
 | DeepWiki | RAG-as-a-Service | `https://mcp.deepwiki.com/sse` | Open | [Devin](https://devin.ai/) |
 | Exa Search | Search | `https://mcp.exa.ai/mcp` | Open | [Exa](https://exa.ai) |
 | Hugging Face | Software Development | `https://hf.co/mcp` | Open | [Hugging Face](https://huggingface.co) |


### PR DESCRIPTION
## Summary

Adds [ContextWire](https://contextwire.dev) to the remote MCP server list.

ContextWire is a free remote MCP server for web search, offering:

- **5 tools**: ask, search, extract, research, batch_search
- **105 search engines** across 22 profiles
- **Free tier**: 1,000 queries/month (no API key required)
- **94.3% SimpleQA accuracy**
- **Transport**: Streamable HTTP (`https://contextwire.dev/mcp`)

GitHub: https://github.com/keptlive/contextwire-mcp

Placed alphabetically in the Open authentication section under the Search category.