### PR TITLE
Add satoshidata.ai — Bitcoin wallet intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
+| Satoshidata | Crypto | `https://satoshidata.ai/mcp/` | API Key | [Satoshidata](https://satoshidata.ai) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |


### PR DESCRIPTION
Adds [satoshidata.ai](https://satoshidata.ai) to the remote MCP servers list.

**Category:** Crypto
**URL:** `https://satoshidata.ai/mcp/`
**Auth:** API Key (also supports L402 Lightning and x402 USDC micropayments)

Bitcoin chain intelligence API with 33M+ labeled addresses. Trust scores, address attribution, transaction verification, fee estimates, mempool stats, and price data. 14 MCP tools, 19 API capabilities.

- Agent card: https://satoshidata.ai/.well-known/agent-card.json
- OpenAPI: https://satoshidata.ai/openapi.json