### PR TITLE
Add MCPBundles — remote MCP server for 500+ production APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
+| MCPBundles | Developer Tools | `https://mcp.mcpbundles.com/hub/` | OAuth2.1 | [MCPBundles](https://mcpbundles.com) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |


### PR DESCRIPTION
Adds MCPBundles to the Remote MCP Server List.

- **Server URL:** `https://mcp.mcpbundles.com/hub/`
- **Auth:** OAuth 2.1
- **Category:** Developer Tools
- **Website:** https://mcpbundles.com

MCPBundles is a hosted platform for discovering, configuring, and running MCP tool bundles. One remote MCP server connects AI agents to 500+ production APIs (Stripe, HubSpot, Postgres, Gmail, and more) with OAuth and credential management.

Already listed on the official MCP ecosystem:
- [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) (community servers)
- [modelcontextprotocol.io/clients](https://modelcontextprotocol.io/clients) (client directory)