### PR TITLE
Add NexVigilant Station — pharmacovigilance MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | DeepWiki | RAG-as-a-Service | `https://mcp.deepwiki.com/sse` | Open | [Devin](https://devin.ai/) |
 | Exa Search | Search | `https://mcp.exa.ai/mcp` | Open | [Exa](https://exa.ai) |
 | Hugging Face | Software Development | `https://hf.co/mcp` | Open | [Hugging Face](https://huggingface.co) |
+| NexVigilant Station | Pharmacovigilance | `https://mcp.nexvigilant.com/mcp` | Open | [NexVigilant](https://nexvigilant.com) |
 | Semgrep | Software Development | `https://mcp.semgrep.ai/sse` | Open | [Semgrep](https://semgrep.dev/) |
 | Remote MCP | MCP Directory | `https://mcp.remote-mcp.com` | Open | [Remote MCP](https://remote-mcp.com/) |
 | OpenMesh | Service Discovery | `https://api.openmesh.dev/mcp` | Open | [OpenMesh](https://openmesh.dev) |


### PR DESCRIPTION
## Summary

Adds [NexVigilant Station](https://nexvigilant.com) to the remote MCP server list.

- **URL:** `https://mcp.nexvigilant.com/mcp`
- **Category:** Pharmacovigilance (drug safety intelligence)
- **Authentication:** Open
- **Transport:** Streamable HTTP (MCP 2025-03-26 spec)
- **Tools:** 165 across 20 data domains
- **Health endpoint:** https://mcp.nexvigilant.com/health

### What it does

NexVigilant Station connects AI agents to pharmacovigilance data sources — FDA FAERS, EudraVigilance, WHO VigiAccess, ClinicalTrials.gov, PubMed, DailyMed, OpenVigil, and reference frameworks (MedDRA, ICH, CIOMS, WHO-UMC). Includes signal detection compute tools (PRR, ROR, IC, EBGM), causality assessment (Naranjo, WHO-UMC), and 6 guided research courses via `nexvigilant_chart_course`.

### Verification

```bash
# Health check
curl https://mcp.nexvigilant.com/health

# Tool count
curl https://mcp.nexvigilant.com/tools | python3 -c "import sys,json; print(len(json.load(sys.stdin)), 'tools')"

# MCP initialize (confirms Streamable HTTP)
curl -X POST https://mcp.nexvigilant.com/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
```

Production server running on Google Cloud Run. All tools annotated with `readOnlyHint: true`.