### PR TITLE
Add 1Stay Hotel Booking — first Travel category entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| [1Stay Hotel Booking](https://1stay.ai) | Travel | `https://mcp.stayker.com/mcp` | OAuth2.1 | [STAYKER](https://1stay.ai) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
## What

Adds [1Stay Hotel Booking](https://1stay.ai) as the first **Travel** category entry in the remote MCP server list.

## Details

- **Server:** `https://mcp.stayker.com/mcp`
- **Auth:** OAuth 2.1
- **Transport:** Streamable HTTP (MCP SDK v1.27.1)
- **Tools:** 7 (search_hotels, get_hotel_details, book_hotel, get_booking, cancel_booking, retrieve_booking, search_tools)
- **Coverage:** 300K+ properties across 140+ countries

1Stay is the first MCP server that completes real hotel reservations inside AI conversations — live rates, real confirmation numbers, and loyalty program eligibility (Hilton, Marriott, IHG). Builders monetize by setting their own booking fee via Stripe Connect.

Try it: https://1stay.ai/playground