### PR TITLE
feat: add Since Today commerce MCP servers (podcast, newsletter, recipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
+| Newsletter Commerce MCP | E-Commerce | `https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp` | Open / API Key | [Since Today](https://sincetoday.com) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
@@ -111,7 +112,9 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
+| Podcast Commerce MCP | E-Commerce | `https://podcast-commerce-mcp.sincetoday.workers.dev/mcp` | Open / API Key | [Since Today](https://sincetoday.com) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
+| Recipe Commerce MCP | E-Commerce | `https://recipe-commerce-mcp.sincetoday.workers.dev/mcp` | Open / API Key | [Since Today](https://sincetoday.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |


### PR DESCRIPTION
Adding three remote MCP servers for content commerce intelligence.

All three are live remote Streamable HTTP endpoints (Cloudflare Workers):
- Free tier: 200 calls/day, no API key required (Open)
- Paid tier: $0.01/call via x402 API key

Servers:
- **Newsletter Commerce MCP**: https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp
- **Podcast Commerce MCP**: https://podcast-commerce-mcp.sincetoday.workers.dev/mcp
- **Recipe Commerce MCP**: https://recipe-commerce-mcp.sincetoday.workers.dev/mcp

GitHub: https://github.com/teamsincetoday