### PR TITLE
Add ZenRows MCP server: web scraping MCP with anti-bot bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| ZenRows | Web Data Extraction Platform | `https://mcp.zenrows.com/mcp` | OAuth | [ZenRows](https://www.zenrows.com) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## ZenRows MCP Server

**URL:** `https://mcp.zenrows.com/mcp`
**Auth:** OAuth
**Category:** Web Data Extraction Platform
**Maintainer:** [ZenRows](https://www.zenrows.com)
**Docs:** https://docs.zenrows.com/integrations/mcp/mcp-overview

### Why it meets the quality criteria

- **Official Support**: built and maintained by the ZenRows team
- **Production Ready**: serves thousands of customers scraping at scale with a 99.9% uptime
- **Active Maintenance**: regularly updated, active npm package at `@zenrows/mcp`
- **Reliability**: backed by ZenRows' Universal Scraper API (JavaScript rendering, residential proxies, anti-bot bypass included)
- **Community**: official docs and support channels

### What it does

Gives AI assistants the ability to fetch any webpage, including JavaScript-heavy sites and pages protected by anti-bot systems and return clean Markdown, plain text, raw HTML, a screenshot, or structured JSON. No proxy management or bot bypass logic required on the agent side.

### Example usage
```
Scrape https://example.com and summarize the content.
```

### Active maintenance evidence

- npm: https://www.npmjs.com/package/@zenrows/mcp
- GitHub: https://github.com/ZenRows/zenrows-mcp