### PR TITLE
Add Savecraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
+| Savecraft | Gaming | `https://mcp.savecraft.gg` | OAuth2.1 | [Savecraft](https://savecraft.gg) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |


### PR DESCRIPTION
Adds [Savecraft](https://savecraft.gg) to the remote MCP server list under a new Gaming category.

Savecraft serves real game save data (characters, gear, skills, progress) and expert reference tools (draft advisors, drop calculators, build optimizers) to AI assistants. OAuth 2.1 with dynamic client registration, works with Claude, ChatGPT, and Gemini.

- **MCP endpoint:** https://mcp.savecraft.gg
- **Website:** https://savecraft.gg
- **GitHub:** https://github.com/joshsymonds/savecraft.gg
- Production-deployed on Cloudflare Workers
- Open source, actively maintained
- Currently supports Diablo II: Resurrected, Magic: The Gathering Arena, RimWorld, Stardew Valley, Clair Obscur, and World of Warcraft