### PR TITLE
Add AgentLair - email identity MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AgentLair | Communication / Email | `https://agentlair-mcp-server.amdal-dev.workers.dev/mcp` | API Key | [AgentLair](https://agentlair.dev) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
AgentLair gives AI agents their own email identity (@agentlair.dev addresses) and credential vault via MCP. One API call setup, no SMTP/DNS config, free tier available.

- **URL**: https://agentlair-mcp-server.amdal-dev.workers.dev/mcp
- **Auth**: API Key
- **Homepage**: https://agentlair.dev
- **npm**: @agentlair/mcp