### PR TITLE
Add Lightyear CryptoPunks MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
+| Lightyear CryptoPunks | Crypto | `https://punks.lightyear.build/api/mcp` | Open | [Lightyear](https://lightyear.build) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |


### PR DESCRIPTION
## New Remote MCP Server: Lightyear CryptoPunks\n\n**Name:** Lightyear CryptoPunks\n**Category:** Crypto\n**URL:** `https://punks.lightyear.build/api/mcp`\n**Authentication:** Open (no API key, rate-limited per IP)\n**Transport:** Streamable HTTP\n**Maintainer:** [Lightyear](https://lightyear.build)\n\n### Description\n\nFree, read-only MCP server for the native CryptoPunks marketplace. 11 tools covering:\n\n- Browse the collection by type and trait\n- Filter 10,000 punks by complex criteria\n- Real-time marketplace listings and floor price\n- Bid depth analysis\n- Merkle root computation and resolution (for Stash bidding system)\n- AI-assisted bid pricing recommendations\n\nBuilt as a public good by Lightyear. No account required."