### PR TITLE
Add FlashAlpha — real-time options analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |
 | Dodo Payments | Payments | `https://mcp.dodopayments.com/sse` | API Key | [Dodo Payments](https://dodopayments.com) |
+| FlashAlpha | Finance | `https://lab.flashalpha.com/mcp` | API Key | [FlashAlpha](https://github.com/FlashAlpha-lab/flashalpha-mcp) |
 | Polar Signals | Software Development | `https://api.polarsignals.com/api/mcp/` | API Key | [Polar Signals](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) |
 | Manifold | Forecasting | `https://api.manifold.markets/v0/mcp` | Open | [Manifold](https://manifold.markets) |
 | Javadocs | Software Development | `https://www.javadocs.dev/mcp` | Open | [Javadocs.dev](https://javadocs.dev) |


### PR DESCRIPTION
Adds [FlashAlpha](https://lab.flashalpha.com/mcp) to the remote MCP server list.

Real-time options analytics for US equities — 23 tools covering gamma/delta/vanna/charm exposure, dealer positioning, 0DTE analytics, SVI volatility surfaces, VRP, Black-Scholes greeks, Kelly sizing, and historical tick data.

- **URL**: `https://lab.flashalpha.com/mcp`
- **Transport**: Streamable HTTP
- **Auth**: API key (per tool call)
- **Category**: Finance
- **GitHub**: https://github.com/FlashAlpha-lab/flashalpha-mcp