### PR TITLE
Add Arcjet - runtime security

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 |------|----------|-------------|----------------|------------|
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
+| Arcjet | Software Development / Security | `https://api.arcjet.com/mcp` | OAuth2.1 | [Arcjet](https://arcjet.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |


### PR DESCRIPTION
Added fully supported [Arcjet](https://arcjet.com) MCP server (https://docs.arcjet.com/mcp-server) for implementing and managing runtime security.