### PR TITLE
Add Podcast, Newsletter & Recipe Commerce MCPs (Cloudflare Workers, API Key auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
+| Newsletter Commerce MCP | E-Commerce | `https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp` | API Key | [teamsincetoday](https://github.com/teamsincetoday) |
+| Podcast Commerce MCP | E-Commerce | `https://podcast-commerce-mcp.sincetoday.workers.dev/mcp` | API Key | [teamsincetoday](https://github.com/teamsincetoday) |
+| Recipe Commerce MCP | E-Commerce | `https://recipe-commerce-mcp.sincetoday.workers.dev/mcp` | API Key | [teamsincetoday](https://github.com/teamsincetoday) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |


### PR DESCRIPTION
Three production-ready remote MCP servers for commerce intelligence:

- **Podcast Commerce MCP** — Extracts sponsors, affiliate products, commerce intelligence from podcast episodes. Deployed on Cloudflare Workers.
- **Newsletter Commerce MCP** — Extracts sponsored content, affiliate products from newsletters (Beehiiv, Substack). Deployed on Cloudflare Workers.
- **Recipe Commerce MCP** — Extracts ingredients, shoppable products, affiliate opportunities from recipe content. Deployed on Cloudflare Workers.

All three: TypeScript, 200 free calls/day free tier, x402 pay-per-use, x-api-key authentication, 643 tests passing.