### PR TITLE
Add AgentNDX — network registry for the agentic web

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Semgrep | Software Development | `https://mcp.semgrep.ai/sse` | Open | [Semgrep](https://semgrep.dev/) |
 | Remote MCP | MCP Directory | `https://mcp.remote-mcp.com` | Open | [Remote MCP](https://remote-mcp.com/) |
 | OpenMesh | Service Discovery | `https://api.openmesh.dev/mcp` | Open | [OpenMesh](https://openmesh.dev) |
-| AgentIndex | Service Discovery | `https://agentndx-production.up.railway.app` | x402 | [AgentIndex](https://github.com/agentndx/agentndx) |
+| AgentNDX | Service Discovery | `https://agentndx.com/mcp` | x402 | [AgentNDX](https://agentndx.com) |
 | OpenZeppelin Cairo Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/cairo/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |
 | OpenZeppelin Solidity Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/solidity/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |
 | OpenZeppelin Stellar Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/stellar/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Semgrep | Software Development | `https://mcp.semgrep.ai/sse` | Open | [Semgrep](https://semgrep.dev/) |
 | Remote MCP | MCP Directory | `https://mcp.remote-mcp.com` | Open | [Remote MCP](https://remote-mcp.com/) |
 | OpenMesh | Service Discovery | `https://api.openmesh.dev/mcp` | Open | [OpenMesh](https://openmesh.dev) |
+| AgentIndex | Service Discovery | `https://agentndx-production.up.railway.app` | x402 | [AgentIndex](https://github.com/agentndx/agentndx) |
 | OpenZeppelin Cairo Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/cairo/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |
 | OpenZeppelin Solidity Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/solidity/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |
 | OpenZeppelin Stellar Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/stellar/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |


### PR DESCRIPTION
Adds AgentNDX to the Service Discovery category.

AgentNDX is a network registry for the agentic web — 50,000+ MCP servers, A2A agents, and x402-enabled services searchable via REST or MCP.

- **MCP endpoint:** `https://agentndx.com/mcp`
- **Auth:** x402 (USDC micropayment on Base) for search; free for browse/stats
- **Site:** https://agentndx.com
- **Open source:** https://github.com/agentndx/agentndx