### PR TITLE
Add LinkMCP - hosted MCP server for LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
+| LinkMCP | Social Media | `https://app.linkmcp.io/api/mcp` | OAuth2.1 | [LinkMCP](https://app.linkmcp.io) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |


### PR DESCRIPTION
LinkMCP is a hosted MCP server that gives AI agents direct access to LinkedIn.

- **25 tools**: profiles, messages, search, post engagement, company data, enrichment
- **Auth**: OAuth 2.1
- **URL**: `https://app.linkmcp.io/api/mcp`
- **Website**: https://app.linkmcp.io

Also listed on Smithery: https://smithery.ai/server/@linkmcp/linkmcp