### PR TITLE
Add CompanyScope - company intelligence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |
+| CompanyScope | Data Analysis | `https://companyscope-mcp.stewwilli.workers.dev/mcp` | Open | [CompanyScope](https://github.com/Stewyboy1990/companyscope-mcp) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |


### PR DESCRIPTION
## New Remote MCP Server: CompanyScope

**URL:** `https://companyscope-mcp.stewwilli.workers.dev/mcp`
**Category:** Data Analysis
**Auth:** Open (no authentication required)

### Description

CompanyScope is a remote MCP server that provides company intelligence from a single tool call. Returns company profiles aggregated from 8 free public sources (Wikipedia, GitHub, SEC EDGAR, RDAP, web scraping, etc.).

- 6 MCP tools: lookup_company, get_tech_stack, get_corporate_registry, get_key_people, get_company_news, get_financials
- No API keys required for core functionality
- Free tier: 25 calls/day
- Hosted on Cloudflare Workers
- Also available on [Apify](https://apify.com/constructive_wainscot/companyscope-mcp)