### PR TITLE
Add AdOps MCP — Cross-Platform Ad Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
+| AdOps MCP | Advertising | `https://mcpize.com/mcp/adops-mcp` | API Key | [AdOps MCP](https://github.com/enzoemir1/adops-mcp) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |


### PR DESCRIPTION
Adds AdOps MCP — AI-powered cross-platform ad management for Google Ads and Meta Ads.

- 14 tools, 4 resources, 42 tests
- Hosted on MCPize
- GitHub: https://github.com/enzoemir1/adops-mcp
- npm: adops-mcp-server | MIT License