### PR TITLE
Add MRC Data -- apparel supply chain data for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
+| MRC Data | Supply Chain Data | `https://api.meacheal.ai/mcp` | API Key | [MEACHEAL](https://api.meacheal.ai) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 


### PR DESCRIPTION
## Server Details

- **Name:** MRC Data
- **Category:** Data Analysis
- **URL:** `https://api.meacheal.ai/mcp`
- **Authentication:** API Key (Bearer token)
- **Maintainer:** [MRC Data](https://github.com/meacheal-ai/mrc-data)

## Description

MRC Data is China's apparel supply chain data infrastructure for AI agents. It provides 10 MCP tools covering 1,040+ verified Chinese suppliers, 351 lab-tested fabrics, and 173 industrial clusters. Every record is enriched with AATCC / ISO / GB lab test data.

## Why it meets the quality criteria

- **Official Support:** Maintained by the MRC Data team at meacheal.ai
- **Production Ready:** Live HTTP transport endpoint serving production traffic
- **Active Maintenance:** Regular updates with expanding supplier and fabric coverage
- **Security:** Bearer token authentication required for all API calls
- **Documentation:** Full API docs at https://api.meacheal.ai/docs
- **Free tier:** API keys available at https://api.meacheal.ai/apply

## Links

- GitHub: https://github.com/meacheal-ai/mrc-data
- Docs: https://api.meacheal.ai/docs
- Demo: https://api.meacheal.ai/demo