### PR TITLE
Add MONEI — European payment platform MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
-| monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
+| MONEI | Payments | `https://mcp.monei.com/mcp` | OAuth2.1 | [MONEI](https://monei.com) || monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |


### PR DESCRIPTION
MONEI is a Payment Institution regulated by Banco de España (#6911) offering an official, production-grade remote MCP server for payment operations.

URL: https://mcp.monei.com/mcp
Auth: OAuth 2.0 + PKCE
Category: Payments
Repo: [github.com/MONEI/MONEI-MCP-Server](https://github.com/MONEI/MONEI-MCP-Server)
Maintained by: MONEI (official)

Supports payment link creation, transaction lookup, analytics, subscriptions, and account info. Security-restricted operations (refunds, charges, payouts) are hard-blocked at the server level.
Joins Stripe, Square, PayPal, Plaid, Ramp, and Mercado Pago in the Payments category.