### PR TITLE
Add Gavelin — State legislative intelligence for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| Gavelin | Government & Policy | `https://mcp.gavelin.ai/mcp` | API Key | [Gavelin](https://gavelin.ai) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
Adds **Gavelin** to the Remote MCP Server List.

Gavelin is a remote MCP server providing state legislative intelligence for AI agents:

- **Category:** Government & Policy
- **URL:** `https://mcp.gavelin.ai/mcp`
- **Transport:** Streamable HTTP
- **Authentication:** API Key (bearer token)
- **Website:** https://gavelin.ai

**7 tools** covering:
- 2M+ bills across all 50 US states
- 1.2M+ speaker-attributed hearing segments across 11 states
- Speaker attribution with published accuracy rates
- AI-generated analytical briefs (issue briefs, bill briefs, hearing briefs)

Entry placed alphabetically between `Find-A-Domain` and `GitHub`.

Thanks for curating this list — remote-only is the right philosophy!
