### PR TITLE
Add QR Business Cards remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
+| QR Business Cards | E-Commerce | `https://qr-business-cards.com/api/mcp` | Open | [QR Business Cards](https://qr-business-cards.com) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |


### PR DESCRIPTION
Adds QR Business Cards to the remote MCP server list.

- **Category:** E-Commerce
- **URL:** `https://qr-business-cards.com/api/mcp`
- **Auth:** Open (no API key required)
- **Transport:** Streamable HTTP
- **What it does:** AI agents can create digital profiles, generate QR codes, and order printed business cards shipped via Printful