### PR TITLE
Add HiveAgent - AI Agent Platform with 1,221+ MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| HiveAgent | AI Agent Platform | `https://hiveagentiq.com/mcp` | API Key | [HiveAgent](https://github.com/fireflyfabs/agentbay-marketplace) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## Add HiveAgent

Adding [HiveAgent](https://github.com/fireflyfabs/agentbay-marketplace) to the remote MCP servers list.

**HiveAgent** is the operating system for the agentic economy — a remote MCP server aggregating 1,221+ tools across 45 verticals.

Key features:
- Every major payment rail: Visa ICC, Mastercard Agent Pay, Stripe MPP, x402, BVNK, Circle CPN, OpenAI ACP, Google UCP
- Agent Highway for multi-agent orchestration
- ERC-8183 work contracts
- FICO credit scores for AI agents
- Hosted remote endpoint: `https://hiveagentiq.com/mcp`

Install via Smithery: `npx @smithery/cli install @hiveagentiq/hiveagent`