### PR TITLE
Add FXMacroData to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
+| FXMacroData | Financial Data | `https://fxmacrodata.com/mcp` | API Key | [FXMacroData](https://fxmacrodata.com) |
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |


### PR DESCRIPTION
Adds [FXMacroData](https://fxmacrodata.com) to the Remote MCP Server List.

**FXMacroData** provides macroeconomic indicators, central bank rates, FX spot rates, COT positioning, and release calendars for 18+ currencies.

| Field | Value |
|-------|-------|
| **Name** | FXMacroData |
| **Category** | Financial Data |
| **URL** | `https://fxmacrodata.com/mcp` |
| **Auth** | API Key |
| **Provider** | [FXMacroData](https://fxmacrodata.com) |

- Official server maintained by FXMacroData
- Production-ready, actively maintained
- API key authentication via query parameter
- [API documentation](https://fxmacrodata.com/api-docs)
- [PyPI package](https://pypi.org/project/fxmacrodata/) also available