### PR TITLE
Add AdWeave — Meta Ads MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AdWeave Meta Ads | Advertising | `https://mcp.adweave.ai/meta-ads-mcp` | API Key / OAuth | [AdWeave](https://adweave.ai) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
AdWeave is a hosted Meta Ads MCP server with 47 tools for campaign management, creatives, audiences, insights, and AI-powered diagnosis. Streamable HTTP transport, API token or OAuth auth. https://adweave.ai