### PR TITLE
Add EP AgentIAM and DELPHI Oracle remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
+| DELPHI Oracle | Research | `https://delphi-oracle.onrender.com/mcp` | API Key | [Achilles](https://github.com/achilliesbot/delphi) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
+| EP AgentIAM | Security | `https://achillesalpha.onrender.com/mcp` | API Key | [Achilles](https://github.com/achilliesbot/achillies-render) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |


### PR DESCRIPTION
## Adding two remote MCP servers

### 1. EP AgentIAM (Security)
- **URL:** `https://achillesalpha.onrender.com/mcp`
- **GitHub:** https://github.com/achilliesbot/achillies-render
- **Description:** AI agent execution safety — risk scoring, integrity checks, memory verification, and orchestration via x402 USDC micropayments on Base Mainnet
- **12 tools** for agent safety and intelligence
- **Authentication:** API Key (x402 USDC micropayments)
- **Transport:** Streamable HTTP
- Production-ready, actively maintained

### 2. DELPHI Oracle (Research)
- **URL:** `https://delphi-oracle.onrender.com/mcp`
- **GitHub:** https://github.com/achilliesbot/delphi
- **Description:** Real-time AI-curated intelligence signals and temporal knowledge graph for the agent economy
- **7 tools** for intelligence and research
- **Authentication:** API Key (x402 USDC micropayments)
- **Transport:** Streamable HTTP
- Production-ready, actively maintained

Both servers are live on Render, listed on Smithery, and registered on 402index.io.