### PR TITLE
Add Parsley MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Parallel Search MCP | Web Search | `https://search-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
+| Parsley | Sales Intelligence | `https://www.parsley.id/api/mcp` | API Key | [Parsley](https://www.parsley.id) |
 | Peek.com | Other | `https://mcp.peek.com` | Open | [Peek.com](https://peek.com) |
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)


### PR DESCRIPTION
Adds Parsley - a remote MCP server for sales intelligence.

- **URL:** `https://www.parsley.id/api/mcp`
- **Auth:** API Key
- **Transport:** Streamable HTTP
- **What it does:** Buyer intent signals, MEDDIC qualification data, and lead scoring for AI assistants. 8 tools and 5 workflow prompts.
- **npm:** @tryparsley/mcp-server