### PR TITLE
Add Two Minute Reports -  MCP server for Marketers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
+| Two Minute Reports | Marketing | `https://mcp.twominutereports.com/mcp` | OAuth2.1 & API Key | [Two Minute Reports](https://twominutereports.com/mcp) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |
 | VibeMarketing | Social Media | `https://vibemarketing.ninja/mcp` | OAuth2.1 | [VibeMarketing](https://vibemarketing.ninja) |


### PR DESCRIPTION
Adds [Two Minute Reports](https://twominutereports.com/) — a remote MCP server that lets AI assistants query marketing data across 22+ platforms using natural language.

**Server URL:** `https://mcp.twominutereports.com/mcp`
**Category:** Marketing
**Authentication:** OAuth2.1 & API Key
**Website:** https://twominutereports.com/mcp
**GitHub:** https://github.com/twominutereports/twominutereports-mcp

## What it does

Two Minute Reports enables users to ask questions about their marketing data in plain English and get answers, charts, and insights directly inside Claude or ChatGPT.

**Supported platforms (22+):**
- **Paid Advertising:** Google Ads, Facebook Ads, LinkedIn Ads, TikTok Ads, Microsoft Ads, Snapchat Ads, Pinterest Ads, Amazon Ads, Apple Search Ads, Twitter Ads
- **Analytics:** Google Analytics 4, Google Trends
- **E-Commerce:** Shopify, WooCommerce, Amazon Seller
- **Email & CRM:** Klaviyo, HubSpot
- **Social Media:** Facebook Insights, Instagram Insights, LinkedIn Pages, YouTube Analytics
- **Local:** Google My Business

**Key features:**
- Cross-platform querying in a single conversation
- Automatic chart and table generation
- Fully hosted — no local installation needed
- No data stored by the MCP server — data flows directly from sources through TMR to the AI assistant

**Supported clients:** Claude.ai (Web & Desktop), ChatGPT Plus, and any MCP-compatible application