### PR TITLE
Add OpenClaw Trust Scorer — Solana agent trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
+| OpenClaw Trust Scorer | Blockchain / Trust | `http://178.104.131.84:8082/mcp` | Open | [OpenClaw Research](https://github.com/baronsengir007/openclaw-trust-scorer) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Parallel Search MCP | Web Search | `https://search-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
## New Remote MCP Server: OpenClaw Trust Scorer

**Category:** Blockchain / Trust & Verification

**URL:** `http://178.104.131.84:8082/mcp`

**Authentication:** Open

**Description:**  
MCP server that provides on-chain trust scoring for Solana wallet addresses. Returns trust_score (0.0–1.0), tier (unknown/emerging/established/verified), transaction count, last activity, and SOL balance. Useful for AI agents evaluating counterparty credibility before delegating tasks or payments.

**Tools provided:**
- `get_trust_score(wallet_address)` — queries Solana mainnet-beta RPC for real on-chain signals
- `list_recent_queries()` — anonymized ecosystem overview (Watering Hole feature)

**Health check:** `http://178.104.131.84:8082/health`  
**A2A agent card:** `http://178.104.131.84:8082/.well-known/agent.json`  
**Source:** https://github.com/baronsengir007/openclaw-trust-scorer

The server uses Streamable HTTP transport (MCP SDK v1.29.0) and has been deployed since 2026-04-12.

---
*Happy to add OAuth/API key auth if that's a requirement for listing. Currently open to maximize discovery during initial deployment phase.*