### PR TITLE
Add BotSpot — AI Trading Bots & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
+| BotSpot | Trading & Investing | `https://mcp.botspot.trade/mcp` | OAuth2.1 | [BotSpot](https://botspot.trade) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |


### PR DESCRIPTION
## Add BotSpot

| Field | Value |
|-------|-------|
| Name | BotSpot |
| Category | Trading & Investing |
| URL | `https://mcp.botspot.trade/mcp` |
| Authentication | OAuth 2.1 (with DCR) |
| Maintainer | [BotSpot](https://botspot.trade) |

**Description:** Full-lifecycle algorithmic trading MCP server. Describe a strategy in plain English → AI generates code → backtest on real historical data → deploy live to 10+ brokers (Schwab, IBKR, Alpaca, Tradier, Coinbase, Binance, Kraken). 32 tools covering stocks, options, crypto, futures, and prediction markets.

- **Website:** https://botspot.trade
- **Setup Guide:** https://botspot.trade/agents
- **GitHub:** https://github.com/Lumiwealth/botspot-mcp
- **MCP Registry:** Published as `io.github.grzesir/botspot-trading`
- **Free tier available**