### PR TITLE
Add Elasticflow MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
+| Elasticflow | Productivity | `https://mcp.elasticflow.app/mcp` | OAuth2.1 | [Elasticflow](https://www.elasticflow.app) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |


### PR DESCRIPTION
## Adding Elasticflow

Elasticflow is an AI-native team workspace — tables, documents, files, and live dashboards in one place. The remote MCP server gives agents full read/write access to a user's workspace via OAuth 2.1.

- **URL**: `https://mcp.elasticflow.app/mcp` (Streamable HTTP)
- **Auth**: OAuth 2.1 with PKCE and dynamic client registration — no API key setup
- **Scopes**: fine-grained per resource (workspaces / tables / documents / files / interfaces, read & write)
- **Tools**: 51 total, grouped into Workspaces (4), Tables (15), Documents (12), Files (4), Interfaces (11)
- **Split servers** also available for clients with tool limits: `/data` (19), `/content` (16), `/platform` (11)

### Quality criteria

- **Official**: maintained by Elasticflow — https://www.elasticflow.app
- **Production ready**: live at `mcp.elasticflow.app`, used by customers
- **Active maintenance**: https://github.com/elasticflowapp/elasticflow-mcp
- **Security**: OAuth 2.1 + PKCE, scoped permissions, HTTPS only
- **Docs**: README with client configs for Claude, ChatGPT, Cursor, VS Code, Windsurf, Zed, Raycast, Cline

### Typical usage

- Sales — pipeline tables, weekly summary docs, client dashboards
- Legal — contract trackers, clause search across documents
- Marketing — campaign trackers, reports with embedded charts
- Ops — inventory / supplier tables, live fulfillment dashboards