### PR TITLE
Add Resemble AI remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |
 | Context Awesome | Specialised Dataset | `https://www.context-awesome.com/api/mcp` | Open | [Context Awesome](https://www.context-awesome.com/) |
+| Resemble AI | Documentation | `https://mcp.resemble.ai/sse` | Open | [Resemble AI](https://resemble.ai) |
 | DeepWiki | RAG-as-a-Service | `https://mcp.deepwiki.com/sse` | Open | [Devin](https://devin.ai/) |
 | Exa Search | Search | `https://mcp.exa.ai/mcp` | Open | [Exa](https://exa.ai) |
 | Hugging Face | Software Development | `https://hf.co/mcp` | Open | [Hugging Face](https://huggingface.co) |


### PR DESCRIPTION
Adds the **Resemble AI** remote MCP server to the list.

| Field | Value |
|---|---|
| Name | Resemble AI |
| Category | Documentation |
| URL | \`https://mcp.resemble.ai/sse\` |
| Authentication | Open |
| Maintainer | [Resemble AI](https://resemble.ai) |

**What it exposes:** Official docs and OpenAPI 3.0 schemas for the [Resemble AI](https://resemble.ai) voice platform — voice cloning, text-to-speech, speech-to-speech, speech-to-text, and deepfake detection. Any MCP-compatible client (Cursor, Claude Code, Claude Desktop, Windsurf, Continue, Cline, etc.) can connect to the hosted SSE endpoint with zero install.

Repo for self-hosting: [resemble-ai/resemble-mcp](https://github.com/resemble-ai/resemble-mcp).