### PR TITLE
Add Not Human Search to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
+| Not Human Search | Search | `https://nothumansearch.ai/mcp` | Open | [Not Human Search](https://nothumansearch.ai) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |


### PR DESCRIPTION
Adding **Not Human Search** — a search engine specifically for AI agents to discover agent-first tools.

**Server details:**
- **URL**: `https://nothumansearch.ai/mcp`
- **Transport**: Streamable HTTP (MCP spec)
- **Authentication**: Open
- **Category**: Search

**MCP tools exposed:**
- `search_agents` — keyword/category/signal search across 700+ agent-first sites
- `get_site_details` — full metadata for a specific site (signals, score, category, tags)
- `get_stats` — index-level stats

**Quality criteria:**
- ✅ **Official**: Maintained by the underlying service
- ✅ **Production-ready**: Stable, deployed on Fly.io, 100% uptime
- ✅ **Active maintenance**: Daily recrawl (launchd cron), schema evolution
- ✅ **Security**: Open endpoint, no PII stored
- ✅ **Reliability**: Auto-recovery via health-guard (detects DB issues, auto-restarts)

Unique angle vs existing entries: NHS is the only MCP server dedicated to discovering *other* agent-first MCP servers and tools — it's infrastructure for the MCP ecosystem itself. 700+ sites indexed and scored by agentic-readiness (llms.txt, OpenAPI, MCP, ai-plugin, schema.org).