### PR TITLE
Add Rove — hosted Playwright browser automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
+| Rove | Browser Automation | `https://api.roveapi.com` | API Key | [Rove](https://roveapi.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |


### PR DESCRIPTION
## Summary

Adds [Rove](https://roveapi.com) to the remote MCP server list.

Rove is a hosted Playwright API for AI agents. It returns **accessibility trees** instead of screenshots, reducing LLM token consumption by ~77%. Zero infrastructure required — browser sessions run on Fly.io.

- **Category:** Browser Automation
- **URL:** `https://api.roveapi.com`
- **Auth:** API Key
- **npm:** [@roveapi/mcp](https://www.npmjs.com/package/@roveapi/mcp)
- **Install:** `npx -y @roveapi/mcp`

**Tools:** navigate, click, fill, extract, screenshot, get_a11y_tree, list_sessions, close_session, account_usage