### PR TITLE
Add AI Dev Jobs to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
+| AI Dev Jobs | Job Board | `https://aidevboard.com/mcp` | Open | [AI Dev Jobs](https://aidevboard.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Remote MCP Server List under **Job Board** (alongside Indeed).

- **Endpoint:** `https://aidevboard.com/mcp`
- **Authentication:** Open (no API key required)
- **Tools:** `search_jobs`, `get_job`, `list_companies`, `get_stats`
- **Transport:** JSON-RPC 2.0 over HTTP
- **Listed in the official MCP registry** as `com.aidevboard/jobs`

AI Dev Jobs is a free jobs board aggregating 5,400+ AI/ML roles from 55+ ATS sources (Greenhouse, Lever, Ashby, etc.), designed so AI agents can search and apply on behalf of users.

Quality criteria alignment:
- Production host on dedicated domain with TLS
- Stable JSON-RPC endpoint returning well-formed `initialize` / `tools/list` responses
- OpenAPI spec at `/openapi.yaml`, RSS at `/feed.xml`, llms.txt, ai-plugin.json all discoverable