### PR TITLE
Add Chain.Love MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| Chain.Love MCP | Crypto | `https://app.chain.love/mcp` | Open | [Chain.Love](https://github.com/Chain-Love) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## What this adds

Adds Chain.Love MCP to the Crypto category.

## Entry

- [Chain.Love MCP](https://github.com/Chain-Love/chain.love-mcp) - Hosted remote MCP gateway that enables AI agents to discover and compare Web3 infrastructure services across 50+ blockchain networks through a single endpoint, including RPCs, indexing, oracles, storage, compute, and developer tools.

## Additional links

- Endpoint: https://app.chain.love/mcp
- Landing page: https://www.chain.love/mcp-gateway
- Documentation: https://chain-love.gitbook.io/mcp-module