### PR TITLE
Add AI Dev Jobs and Not Human Search MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AI Dev Jobs | Job Board | `https://aidevboard.com/mcp` | Open | [AI Dev Jobs](https://aidevboard.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
@@ -101,6 +102,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
+| Not Human Search | Search / MCP Directory | `https://nothumansearch.ai/mcp` | Open | [Not Human Search](https://nothumansearch.ai) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |


### PR DESCRIPTION
Adds two new remote MCP servers:

**AI Dev Jobs** (Job Board category) — https://aidevboard.com/mcp
Search 8,400+ AI/ML engineering jobs from 580 company ATS boards. Open/no-auth remote MCP server with 4 tools: `search_jobs`, `get_job`, `list_companies`, `get_stats`. Published to the official MCP registry as `com.aidevboard/jobs`.

**Not Human Search** (Search / MCP Directory category) — https://nothumansearch.ai/mcp
Search engine ranking sites by agentic readiness — 8,000+ sites scored across 7 signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). Open/no-auth remote MCP server with 8 tools including `search_agents`, `verify_mcp` (live JSON-RPC probe), and `get_top_sites`. Published to the official MCP registry as `ai.nothumansearch/search`.

Both are production-ready, actively maintained, listed in the official `registry.modelcontextprotocol.io`, and have no auth requirement (open/public read).