### PR TITLE
Add Kite MCP Server (Zerodha Kite Connect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Invidio | Video Platform | `https://mcp.invideo.io/sse` | OAuth2.1 | [Invidio](https://invideo.io/) |
 | Jam | Software Development | `https://mcp.jam.dev/mcp` | OAuth2.1 | [Jam.dev](https://jam.dev/) |
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
+| Kite MCP Server | Trading | `https://kite-mcp-server.fly.dev/mcp` | OAuth2.1 | [Kite MCP Server](https://github.com/Sundeepg98/kite-mcp-server) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |


### PR DESCRIPTION
Adds **Kite MCP Server** — an open-source remote MCP server for Zerodha's Kite Connect API (India's largest retail broker by active clients).

### Why it fits the list's criteria

- **Remote + hosted**: deployed at `https://kite-mcp-server.fly.dev/mcp` (Fly.io, bom region)
- **OAuth 2.1** with PKCE and dynamic client registration (RFC 7591); per-user Kite developer-app credentials
- **Production ready**: v1.2.0, 330+ tests, security audit (181 findings resolved), Litestream WAL backup to Cloudflare R2
- **Active maintenance**: author-maintained; `CHANGELOG.md`, `SECURITY.md`, architecture docs on the repo

### What it does

- 80+ MCP tools: portfolio, holdings, orders, GTT, alerts, backtesting (SMA/RSI/breakout/mean-reversion), options Greeks (Black-Scholes), paper trading, Telegram briefings
- 9-check riskguard safety layer (kill switch, per-order notional cap, daily value cap, rate limit, duplicate detection, confirmation gate)
- SEBI April 2026 retail-algo-framework aware; DPDP Act 2023 compliance scaffolding
- MCP Apps widgets (portfolio, activity, orders, alerts), Prompts (morning_brief, trade_check, eod_review), structuredContent on all tools

### Links

- Repo: https://github.com/Sundeepg98/kite-mcp-server
- Live server: https://kite-mcp-server.fly.dev/mcp
- MCP Registry manifest: `io.github.sundeepg98/kite-mcp-server`