### PR TITLE
Add ZIP Code & County MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| ZIP Code & County | Geographic Data | `https://zipcodeandcounty.com/api/mcp` | Open / API Key | [zipcodeandcounty.com](https://zipcodeandcounty.com) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## Server

- **Name:** ZIP Code & County
- **Category:** Geographic Data
- **URL:** `https://zipcodeandcounty.com/api/mcp`
- **Authentication:** Open (no key for low-volume use) / API Key (for higher tiers)
- **Maintainer:** [zipcodeandcounty.com](https://zipcodeandcounty.com)

## What it does

Hosted streamable-HTTP MCP server exposing **7 tools** for US geographic data:

- `lookup_zip` — full ZIP record (city, county FIPS, coords, timezone, area codes, demographics)
- `search_zips` — autocomplete by ZIP prefix, city, or county
- `nearby_zips` — every ZIP within N miles of a center, sorted by distance
- `zip_distance` — haversine + driving-time between two ZIPs
- `county_info` — county summary by 5-digit FIPS, with adjacent counties
- `state_summary` — state rollup + top counties by population
- `airports_near_zip` — 10 closest major US airports

## Why it's a fit for this list

- **Hosted, public HTTPS endpoint** — no install, copy-paste config and go
- **Open by default** — no auth required for 5 req/day per anonymous caller (free key for 200/mo, paid tiers for higher)
- **Production-ready** — backed by a Next.js 16 + Supabase stack with rate limiting and observability
- **Public-domain data** — US Census ACS 5-year, USPS, HUD, NANPA, NCES, BEA, IANA. No proprietary data, no licensing surprises
- **Standard transport** — JSON-RPC 2.0 over HTTP at /api/mcp (streamable)

## Tested with

- Claude Desktop
- Cursor
- Zed
- Windsurf
- ChatGPT (developer-mode connectors)

## Try it without an MCP client

```bash
curl -X POST https://zipcodeandcounty.com/api/mcp \
  -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

## Docs

- Setup guide for all major clients: https://github.com/qileza/zip-code-free-api/tree/main/examples/mcp
- Site: https://zipcodeandcounty.com/mcp
- OpenAPI 3.0 spec: https://zipcodeandcounty.com/openapi.json