### PR TITLE
Add SlideForge — remote PowerPoint MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| SlideForge | Presentations | `https://api.slideforge.dev/mcp/` | OAuth2.1 & API Key | [SlideForge](https://slideforge.dev) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
Adding **SlideForge** — a remote-only MCP server that fits this list's scope precisely.

## Details

- **URL**: `https://api.slideforge.dev/mcp/`
- **Category**: Presentations
- **Auth**: OAuth2.1 (Claude Desktop) + Bearer API key (other clients)
- **Maintainer**: [SlideForge](https://slideforge.dev) by Smart Data Brokers GmbH, Zurich
- **License**: MIT (for the client-config repo)
- **Source**: [smartdatabrokers/slideforge-mcp](https://github.com/smartdatabrokers/slideforge-mcp)

## What it does

Generates consulting-quality PowerPoint (.pptx) files from natural language or structured component specs. Works with Claude Desktop, Cursor, Windsurf, Cline, Claude Code, and any MCP client.

- **35 composable components** (Metric, BarList, OrgChart, Waterfall, Gantt, RAGScorecard, ThreeHorizons, MaturityModel, Heatmap)
- **Two engines**: deterministic render (sub-second, $0.03–$0.05/slide) and creative AI (~30s, $0.20/slide)
- **Real editable .pptx output** (not images, not HTML export)
- **Free $3 credit on signup**, no subscription

## Why it fits the list

- Remote-only service (no local install, no local server binary)
- Production-grade uptime (hosted at `api.slideforge.dev`)
- OAuth 2.1 for Claude Desktop + API key for everything else
- Actively maintained by Smart Data Brokers GmbH
- Unique category coverage — "Presentations" wasn't represented before

Thanks for curating this list!