### PR TITLE
Correct Hive Intelligence URL, auth method, and category

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
-| Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
+| Hive Intelligence | Crypto / DeFi | `https://mcp.hiveintelligence.xyz/mcp` | API Key | [Hive Intelligence](https://hiveintelligence.xyz/) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |


### PR DESCRIPTION
Three factual corrections to the Hive Intelligence row.

### 1. URL: `https://hiveintelligence.xyz/mcp` → `https://mcp.hiveintelligence.xyz/mcp`

The original URL is a 307 redirect to a marketing page. The corrected URL is the actual remote streamable HTTP MCP endpoint and returns 200 directly. A reader who copies the original URL straight into an MCP client hits the redirect page, not the server.

Quick verification:
```bash
$ curl -sI https://mcp.hiveintelligence.xyz/mcp -o /dev/null -w "%{http_code}\n"
200
$ curl -sI https://hiveintelligence.xyz/mcp -o /dev/null -w "%{http_code} -> %{redirect_url}\n"
307 -> https://hiveintelligence.xyz/crypto-mcp
```

### 2. Authentication: `OAuth 2.1` → `API Key`

Hive authenticates via `Authorization: Bearer <key>` or `x-api-key: <key>` HTTP headers, not OAuth 2.1. The repo's inclusion criteria accepts API Key auth, so Hive still qualifies — just needed correct labeling to match what the server actually expects.

### 3. Category: `Crypto` → `Crypto / DeFi`

Hive's tool surface spans market data, DeFi analytics (TVL, yields, pool data, protocol health), wallet intelligence, and security grounding — not only crypto market data. The two-category label is more accurate for readers filtering by use case.

No structural changes to the row layout.