### PR TITLE
Add xmp4 — hosted MCP for reading OSS libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
 | Zenable | Security | `https://mcp.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |
 | Zine | Memory | `https://www.zine.ai/mcp` | OAuth2.1 | [Zine](https://www.zine.ai/) |
+| xmp4 | Software Development | `https://mcp.example4.ai/mcp` | Open | [0ics srl](https://example4.ai) |
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |
 | Context Awesome | Specialised Dataset | `https://www.context-awesome.com/api/mcp` | Open | [Context Awesome](https://www.context-awesome.com/) |


### PR DESCRIPTION
Adding xmp4 to the remote MCP server list.

- **URL**: https://mcp.example4.ai/mcp (Streamable-HTTP)
- **Auth**: Open (no auth required, free tier)
- **Category**: Software Development
- **What it does**: semantic code knowledge base for AI agents. 17 SCIP-backed tools over 800+ pre-indexed OSS libraries (C#, Java, TS, Python, Rust, PHP+). One call to get real source, typed callers, usages, tests, hierarchies — replaces the "clone + grep" workflow.
- **Quality criteria**:
  - ✅ Remote-only (hosted)
  - ✅ Streamable-HTTP transport
  - ✅ Tool annotations: all tools are read-only (\`readOnlyHint: true\`)
  - ✅ Already on the Official MCP Registry as \`ai.example4/xmp4\`

**Links:**
- Landing: https://example4.ai
- Skill file: https://example4.ai/xmp4-skill.md
- Registry: https://registry.modelcontextprotocol.io/v0/servers?search=xmp4

🤖 Generated with [Claude Code](https://claude.com/claude-code)