### PR TITLE
Add namemyapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
+| namemyapp | Productivity | `https://mcp.namemy.app/mcp` | OAuth2.1 | [namemyapp](https://namemy.app/agents) |
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |


### PR DESCRIPTION
## Summary

Adds **namemyapp** — AI-powered business name generator with integrated domain registration. Generate brandable names with live availability + one-click buy URLs.

- **Server URL (OAuth 2.1):** `https://mcp.namemy.app/mcp`
- **Direct endpoint (Bearer auth, for API requests):** `https://mcp.namemy.app/direct`
- **Category:** Productivity
- **Maintainer:** [namemyapp](https://namemy.app/agents)
- **Docs / Agents page:** https://namemy.app/agents
- **npm packages:** [`@namemyapp/mcp`](https://www.npmjs.com/package/@namemyapp/mcp), [`@namemyapp/cli`](https://www.npmjs.com/package/@namemyapp/cli)

## Quality criteria

- **Official Support** — operated by namemyapp (the company behind namemy.app)
- **Production Ready** — running on Cloudflare Workers, OAuth 2.1 with dynamic client registration, public and live
- **Active Maintenance** — npm packages currently at 1.1.x, regular releases
- **Security** — OAuth 2.1 with PKCE on `/mcp`; bearer-token `/direct` endpoint for API-driven flows; the `WWW-Authenticate` resource metadata is published at `/.well-known/oauth-protected-resource/mcp`
- **What it does** — generates brandable business names, checks domain availability across 500+ TLDs in real time, and returns one-click purchase URLs so the agent can hand the user a buyable result

## Test

```bash
# Unauthenticated probe — should return 401 with WWW-Authenticate Bearer challenge
curl -i -X POST -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" https://mcp.namemy.app/mcp
```

Adds one row to the table under Productivity, between `mypromind.com` and `Neon`.