### PR TITLE
Add Bernstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Please note that <a href="https://platform.openai.com/docs/guides/developer-mode
 Official support for MCP in API requests is supported by the following LLM providers:
 
 - [Anthropic](https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector)
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Multi-agent orchestrator with remote MCP server mode over HTTP. Exposes task management, agent control, and cost tracking tools.
 - [OpenAI](https://platform.openai.com/docs/guides/tools-remote-mcp)
 - [Gemini](https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#model_context_protocol_mcp)
 


### PR DESCRIPTION
Re-opens #256 with the canonical `https://github.com/sipyourdrink-ltd/bernstein` URL after the project transferred from my personal account to the @sipyourdrink-ltd organization. Same content as the previous PR, only the GitHub URL was updated.