### PR TITLE
Add RentAHuman remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
+| RentAHuman | Marketplace | `https://rentahuman.ai/api` | API Key | [RentAHuman](https://rentahuman.ai) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |


### PR DESCRIPTION
Adds [RentAHuman](https://rentahuman.ai) to the remote MCP server list.

RentAHuman is a marketplace where AI agents hire humans for physical-world tasks. The API uses API key authentication and provides 60+ tools for searching, hiring, and managing human workers with escrow payments.

- **Category:** Marketplace
- **URL:** \`https://rentahuman.ai/api\`
- **Authentication:** API Key
- **Maintainer:** [RentAHuman](https://rentahuman.ai)