### PR TITLE
Add ManyMeet to the services list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
+| ManyMeet | Webinar Intelligence | `https://app.getmanymeet.com/mcp/` | OAuth2.1 | [ManyMeet](https://getmanymeet.com) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |


### PR DESCRIPTION
Adds ManyMeet — hosted MCP server for webinar analytics on Zoom Meeting-based webinars. Remote, OAuth 2.1, 16 tools.