### PR TITLE
Add Meelion MCP - Brazilian fixed income financial data

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
+| Meelion MCP | Finance | `https://mcp.meelion.com/` | Open | [Meelion](https://meelion.com) |
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |


### PR DESCRIPTION
## New Remote MCP Server: Meelion MCP

| Field | Value |
|-------|-------|
| **Name** | Meelion MCP |
| **Category** | Finance |
| **URL** | `https://mcp.meelion.com/` |
| **Authentication** | Open |
| **Maintainer** | [Meelion](https://meelion.com) |

### About

Meelion MCP provides Brazilian fixed income and financial data for AI applications. It exposes structured, LLM-ready data via JSON-RPC including:

- Selic and CDI rates
- IPCA inflation index
- CDB/LCI/LCA investment rankings
- FX rates (USD, EUR), gold and Bitcoin quotes

No API key or authentication required — just connect and go.

### Repository

https://github.com/Meelion-com/meelion-mcp
