### PR TITLE
Add OpenClaw Trust Scorer — Solana wallet trust scoring (Blockchain category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Hugging Face | Software Development | `https://hf.co/mcp` | Open | [Hugging Face](https://huggingface.co) |
 | Semgrep | Software Development | `https://mcp.semgrep.ai/sse` | Open | [Semgrep](https://semgrep.dev/) |
 | Remote MCP | MCP Directory | `https://mcp.remote-mcp.com` | Open | [Remote MCP](https://remote-mcp.com/) |
+| OpenClaw Trust Scorer | Blockchain | `https://facilities-radical-advantage-flashers.trycloudflare.com/mcp?src=mcpso` | Open | [OpenClaw Research](https://github.com/baronsengir007/openclaw-trust-scorer) |
 | OpenMesh | Service Discovery | `https://api.openmesh.dev/mcp` | Open | [OpenMesh](https://openmesh.dev) |
 | OpenZeppelin Cairo Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/cairo/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |
 | OpenZeppelin Solidity Contracts | Software Development | `https://mcp.openzeppelin.com/contracts/solidity/mcp` | Open | [OpenZeppelin](https://openzeppelin.com) |


### PR DESCRIPTION
## OpenClaw Trust Scorer

**Category:** Blockchain  
**Auth:** Open (no authentication required)  
**URL:** `https://facilities-radical-advantage-flashers.trycloudflare.com/mcp?src=mcpso`

### What it does

Scores the trustworthiness of any Solana wallet address based on empirical on-chain data:
- **Trust score** (0–1) — composite of on-chain signals  
- **Tier** — `verified` / `established` / `active` / `new` / `empty`
- **Transaction count** and **last activity** timestamp  
- **Balance tier** and **liveness** status

### Usage (Claude Code or Claude Desktop)

```bash
claude mcp add --transport http "openclaw-trust-scorer" https://facilities-radical-advantage-flashers.trycloudflare.com/mcp
```

Or via Cursor / VS Code:
```json
{
  "mcpServers": {
    "openclaw-trust-scorer": {
      "type": "http",
      "url": "https://facilities-radical-advantage-flashers.trycloudflare.com/mcp"
    }
  }
}
```

### Source

GitHub: https://github.com/baronsengir007/openclaw-trust-scorer  
Also listed on: [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) as `io.github.baronsengir007/trust-scorer`

---
*Part of the OpenClaw agent economy research program — measuring distribution channel reach for MCP vs A2A registries.*