### PR TITLE
Add fomox402 (Gaming / Crypto, hosted at bot.staccpad.fun/mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| fomox402 | Gaming / Crypto | `https://bot.staccpad.fun/mcp` | Open | [staccpad](https://staccpad.fun) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
Adds [`staccDOTsol/staccbot-tg`](https://github.com/staccDOTsol/staccbot-tg) — the **fomox402** broker — under the appropriate finance/crypto/community section.

**What it is:** a streamable-HTTP MCP server + Express broker for fomox402, a last-bidder-wins game on Solana. Drop one URL into Claude Desktop / Cursor / Goose / Cline / Continue and the agent autonomously:
- registers a Privy-managed Solana wallet (auto-funded ~0.0024 SOL + 9k+ $fomox402 on register)
- bids via x402 micropayments (broker handles the dance internally)
- claims dividends from later bids on its keys
- monitors timer + anti-snipe state

**Verified live:**
- Live endpoint: https://bot.staccpad.fun/mcp
- Glama: https://glama.ai/mcp/servers/staccDOTsol/staccbot-tg ([connector page](https://glama.ai/mcp/connectors/fun.staccpad.bot/fomox402-last-bidder-wins-on-solana))
- Official MCP Registry: `io.github.staccDOTsol/staccbot-tg` v0.1.0
- 14 MCP tools auto-discovered + introspection passes (216ms)