### PR TITLE
Add Xiaohongshu XHS RedNote MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| Xiaohongshu XHS RedNote | Social Media | `https://mcp.52choujiang.com/xhs/mcp` | API Key | [52choujiang](https://52choujiang.com/assistant) |
 
 
 # Remote MCP Installation Guide

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
-| Xiaohongshu XHS RedNote | Social Media | `https://mcp.52choujiang.com/xhs/mcp` | API Key | [52choujiang](https://52choujiang.com/assistant) |
+| Xiaohongshu XHS RedNote | Social Media | `https://mcp.52choujiang.com/xhs/mcp` | API Key | [SocialDataX](https://socialdatax.com) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
Adds a production remote MCP server for Xiaohongshu / XHS / RedNote social media data workflows.

- Remote MCP endpoint: https://mcp.52choujiang.com/xhs/mcp
- Authentication: API Key
- Maintainer/docs: https://52choujiang.com/assistant
- Public repo: https://github.com/DevinChen2014/xiaohongshu-xhs-rednote-mcp