### PR TITLE
Add MCP Data API - 16 developer data tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
+| MCP Data API | Developer Data Tools | `https://compliant-milton-hybrid-hoped.trycloudflare.com/mcp` | Open | [155143783](https://github.com/155143783/mcp-data-api) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |


### PR DESCRIPTION
## MCP Data API

**GitHub**: https://github.com/155143783/mcp-data-api
**MCP Endpoint**: https://compliant-milton-hybrid-hoped.trycloudflare.com/mcp

MCP Server with 16 developer data tools using StreamableHTTP transport:
- GitHub Trending & User Info
- NPM Downloads & Package Info
- HackerNews Top Stories
- Crypto Prices & Gas Tracker
- Weather & News
- Stock Quotes & Forex
- IP Lookup, URL Shortener, QR Generator

- Open authentication (no API key required)
- MIT Licensed
- v1.0.0 Released

*Follows contribution guidelines.*