### PR TITLE
Add Hashlock Markets to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
+| Hashlock Markets | Crypto | `https://hashlock.markets/mcp` | API Key (SIWE) | [Hashlock Markets](https://hashlock.markets) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |


### PR DESCRIPTION
…te MCP Server List

Adding Hashlock Markets to the Remote MCP Server List under Crypto category.

**Server:** `https://hashlock.markets/mcp` (Streamable HTTP) **Authentication:** SIWE-issued bearer token (functions as API Key after sign-in flow at `hashlock.markets/sign/login`) **Maintainer:** Hashlock Markets (Hashlock Corp., Delaware C-Corp)

**Quality criteria self-check:**
- ✅ Officially maintained by Hashlock Corp.
- ✅ Production ready, live on Ethereum, Bitcoin, SUI mainnets
- ✅ Active maintenance (recent npm publishes, MCP registry presence)
- ✅ Authentication via SIWE bearer token
- ✅ Documentation: https://hashlock.markets/docs

What it does: Sealed-bid RFQ + HTLC atomic settlement protocol exposed as six MCP tools (`create_rfq`, `respond_rfq`, `create_htlc`, `withdraw_htlc`, `refund_htlc`, `get_htlc`). Cross-chain OTC trading without bridges or custodians.

Disambiguation: Hashlock Markets (`hashlock.markets`) is unrelated to Hashlock Pty Ltd (`hashlock.com`, Australian smart contract auditor).