### PR TITLE
Add techmanual.ai — hardware documentation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Zine | Memory | `https://www.zine.ai/mcp` | OAuth2.1 | [Zine](https://www.zine.ai/) |
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |
+| techmanual.ai | Documentation | `https://mcp.techmanual.ai/mcp/` | API Key | [techmanual.ai](https://techmanual.ai) |
 | Context Awesome | Specialised Dataset | `https://www.context-awesome.com/api/mcp` | Open | [Context Awesome](https://www.context-awesome.com/) |
 | DeepWiki | RAG-as-a-Service | `https://mcp.deepwiki.com/sse` | Open | [Devin](https://devin.ai/) |
 | Exa Search | Search | `https://mcp.exa.ai/mcp` | Open | [Exa](https://exa.ai) |


### PR DESCRIPTION
## Summary

Adds [techmanual.ai](https://techmanual.ai) to the Documentation category.

| Field | Value |
|---|---|
| **Name** | techmanual.ai |
| **Category** | Documentation |
| **URL** | `https://mcp.techmanual.ai/mcp/` |
| **Auth** | API Key (`Authorization: Bearer tmai_...`) |
| **Maintainer** | [techmanual.ai](https://techmanual.ai) |

techmanual.ai provides structured, searchable technical documentation for test & measurement, industrial automation, and power electronics equipment — indexed from manufacturer PDFs and served via a remote MCP server. Covers oscilloscopes, spectrum analyzers, power supplies, DMMs, and more from Keysight, Rohde & Schwarz, Tektronix, and others.

- Free API keys available instantly at https://techmanual.ai/setup (no account required)
- Also listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.techmanual-ai/techmanual`
- Transport: Streamable HTTP (`/mcp/` endpoint)