### PR TITLE
Add Ploi Cloud MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| Ploi Cloud | Software Development | `https://ploi.cloud/mcp` | OAuth2.1 | [Ploi Cloud](https://ploi.cloud) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
This PR adds the official https://ploi.cloud MCP server into the list. Everything you can do from the UI you can do with this MCP. Creating new applications, deploying it and adding services where needed. You can now deploy applications on the Ploi Cloud infrastructure without needing any server knowledge.

Endpoint: https://ploi.cloud/mcp
Docs: https://ploi.cloud/features/ai & https://ploi.cloud/documentation/ai