### PR TITLE
Add GetTreatmentHelp and GetPracticeHelp — Healthcare remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| GetPracticeHelp | Healthcare | `https://gph-mcp-server.pages.dev/mcp` | Open | [GetPracticeHelp](https://getpracticehelp.com) |
+| GetTreatmentHelp | Healthcare | `https://gth-mcp-server.pages.dev/mcp` | Open | [GetTreatmentHelp](https://gettreatmenthelp.com) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
## Summary

Adds two open, remote-hosted MCP servers in the Healthcare category, inserted alphabetically between Find-A-Domain and GitHub.

### GetTreatmentHelp
- **URL:** `https://gth-mcp-server.pages.dev/mcp`
- **Auth:** Open (free tier: 10 calls/month, no key required)
- **Data:** 12,373 SAMHSA-verified substance abuse and mental health treatment facilities, all 50 US states + DC
- **Tools:** `search_facilities`, `get_facility_detail`, `list_states`, `get_treatment_types`
- **Also on:** Smithery (`cbeggroup/gettreatmenthelp`), official MCP Registry (`com.gettreatmenthelp/gettreatmenthelp`), PulseMCP
- **Repo:** https://github.com/Crindo2/gth-mcp-server

### GetPracticeHelp
- **URL:** `https://gph-mcp-server.pages.dev/mcp`
- **Auth:** Open (free tier: 25 calls/month, no key required)
- **Data:** 103,000+ verified healthcare service vendors across 25 categories (medical billing, credentialing, EHR, legal, compliance, etc.), all 50 US states + DC
- **Tools:** `match_practice`, `search_providers`, `get_provider_detail`
- **Also on:** Smithery (`cbeggroup/getpracticehelp`)
- **Repo:** https://github.com/Crindo2/gph-mcp-server

Both servers are production-ready, actively maintained, and hosted on Cloudflare Pages with monthly data refreshes.