### PR TITLE
Add CanYouGrab.it — confidence-scored domain availability checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
+| CanYouGrab.it | Productivity | `https://api.canyougrab.it/mcp` | OAuth2.1 | [CanYouGrab.it](https://canyougrab.it) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |


### PR DESCRIPTION
Adds CanYouGrab.it to the remote MCP servers list. Provides confidence-scored domain availability checking via real-time DNS + WHOIS lookups, with bulk checking up to 100 domains per request.

- **URL**: `https://api.canyougrab.it/mcp` (streamable-http)
- **Auth**: OAuth 2.1 with dynamic client registration (Auth0 at `login.canyougrab.it`)
- **Tools**: `check_domains`, `get_domain_info`, `check_usage` (all read-only)

Quality criteria:
- Officially maintained by canyougrab.it
- Production-ready, public free tier (500 lookups/month, no card required)
- OAuth 2.1 with PKCE + DCR
- Listed in MCP Registry: `io.github.einiba/canyougrab` v1.1.1