### PR TITLE
Add SciWeave to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
+| SciWeave | Scientific Research | `https://mcp.sciweave.com/mcp` | API Key | [DeSci Labs](https://sciweave.com/web/mcp) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |


### PR DESCRIPTION
Adding [SciWeave](https://sciweave.com/web/mcp) — a hosted remote MCP that grounds Claude/ChatGPT/Cursor/Windsurf in 300M scientific works with verifiable DOIs.

| Field | Value |
|---|---|
| Name | SciWeave |
| Category | Scientific Research (matches BGPT's existing category) |
| URL | `https://mcp.sciweave.com/mcp` (streamable-http) |
| Auth | API Key (`Authorization: Bearer <key>`) |
| Maintainer | DeSci Labs |

Production status:
- Listed on [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=sciweave) as `io.github.desci-labs/sciweave-mcp`
- `server.json`: https://github.com/desci-labs/sciweave-mcp/blob/main/server.json
- API key signup: https://mcp.sciweave.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)