### PR TITLE
Add SprintFlint to Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
+| SprintFlint | Project Management | `https://mcp.sprintflint.com` | API Key | [SprintFlint](https://sprintflint.com) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |


### PR DESCRIPTION
Adding [SprintFlint](https://sprintflint.com) — a sprint-native Jira alternative for small eng teams.

## Server details
- **Name:** SprintFlint
- **Category:** Project Management
- **URL:** `https://mcp.sprintflint.com`
- **Authentication:** API Key (Bearer token — same token as REST API)
- **Maintainer:** [SprintFlint](https://sprintflint.com)
- **MCP protocol version:** 2025-06-18

## Quality criteria
- ✅ **Official Support:** Server is operated and maintained by SprintFlint, the underlying SaaS.
- ✅ **Production Ready:** Server is live in production at `mcp.sprintflint.com`.
- ✅ **Active Maintenance:** Active development; the underlying app ships changes weekly. See [/changelog](https://sprintflint.com/changelog).
- ✅ **Security:** Bearer-token auth on every request; tokens are scoped per account.
- ✅ **Documentation:** Setup docs at [sprintflint.com/mcp](https://sprintflint.com/mcp) with one-block JSON config for Claude Desktop / Cursor / Zed and a `claude mcp add` snippet for Claude Code.

## Tools exposed
Eight day-one tools: `list-projects`, `list-sprints`, `list-issues`, `my-issues`, plus issue/comment creation and updates. Devs can read sprint state and file tickets without leaving the editor.

Inserted alphabetically between Sentry and Stack Overflow in the table.