### PR TITLE
Add Pyrimid remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
+| Pyrimid | Payments | `https://pyrimid.ai/api/mcp` | Open | [Pyrimid](https://pyrimid.ai) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |


### PR DESCRIPTION
Adds Pyrimid as an open remote MCP server for agent-commerce payments.\n\nServer: https://pyrimid.ai/api/mcp\nCatalog: https://pyrimid.ai/api/v1/catalog\nDiscovery: https://pyrimid.ai/agents.txt