### PR TITLE
Add Airtable (official remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adds the official Airtable remote MCP server.

| Name | Category | URL | Authentication | Maintainer |
|------|----------|-----|----------------|------------|
| Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |

**Quality criteria:**

- **Official Support:** server is published and operated by Airtable; listed in the official [MCP Registry](https://registry.modelcontextprotocol.io/v1/servers?search=com.airtable) as `com.airtable/mcp` with verified `airtable.com` domain ownership.
- **Production Ready:** publicly available at `mcp.airtable.com/mcp` and used by the official Airtable plugins for Claude Code and Codex.
- **Authentication:** OAuth 2.1 (with token rotation and PKCE).
- **Public artifacts:** plugins, skills, and install instructions are open-source at https://github.com/airtable/skills.

**Placement:** alphabetically at the top of the OAuth section, before Asana.
**Category:** `Database` — follows the precedent set by Prisma Postgres and Supabase.