### PR TITLE
Add Shellgate — security gateway for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
+| Shellgate | Security | `https://<instance>.shellgate.cloud/mcp` | API Key | [Shellgate](https://github.com/matthiastjong/shellgate) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |


### PR DESCRIPTION
## Summary

Adds [Shellgate](https://github.com/matthiastjong/shellgate) to the remote MCP server list.

Shellgate is a self-hosted security gateway that sits between AI agents and infrastructure — agents get scoped tokens, never see real credentials, and dangerous commands require human approval. It exposes all agent-facing functionality as an MCP server using Streamable HTTP transport with API Key (bearer token) authentication.

**Key capabilities:**
- API request proxying with credential injection (agents never see real secrets)
- SSH execution with guard protection and human-in-the-loop approval
- Credential vault, webhook handling, agent memories, org skills, and wiki
- Self-hostable via Docker or available as [Shellgate Cloud](https://shellgate.cloud) (managed)
- MIT licensed, open source

**Entry details:**
- **Category:** Security
- **URL:** `https://<instance>.shellgate.cloud/mcp` (per-instance — self-hosted or Shellgate Cloud)
- **Authentication:** API Key (bearer token)
- **Maintainer:** [Shellgate](https://github.com/matthiastjong/shellgate)