### PR TITLE
Add TensorFeed (Specialised Dataset, Open auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
-| TensorFeed | Specialised Dataset | `https://tensorfeed.ai/api/mcp` | Open | [TensorFeed](https://tensorfeed.ai) |
+| TensorFeed | Specialised Dataset | `https://mcp.tensorfeed.ai/mcp` | Open | [TensorFeed](https://tensorfeed.ai) |
 
 
 # Remote MCP Installation Guide

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| TensorFeed | Specialised Dataset | `https://tensorfeed.ai/api/mcp` | Open | [TensorFeed](https://tensorfeed.ai) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## Server

**Name**: TensorFeed
**Category**: Specialised Dataset
**URL**: `https://tensorfeed.ai/api/mcp`
**Auth**: Open
**Maintainer**: [TensorFeed](https://tensorfeed.ai)

## What it does

A single remote MCP server providing aggregated, attributed AI ecosystem data across multiple domains via 17 free tools. Built for the case where an agent needs cross-domain context (security, news, model pricing, regulatory data) without wiring N parallel API integrations.

Tools include: `get_cve_record`, `get_kev_catalog`, `get_epss_score`, `query_osv_vulnerabilities` (security advisories from MITRE/CISA/FIRST.org/OSV); `get_news_articles` (100+ AI sources); `get_models` (cross-lab pricing); `get_status_summary` (OpenAI/Anthropic/Google/etc.); `search_sec_edgar` (SEC filings); `query_fda_drug_recalls`, `query_fda_drug_labels`, `query_fda_device_events`, `query_fda_food_recalls`, `query_fda_drug_events` (FDA regulatory data); plus US energy/economy indicators via FRED, EIA, BLS.

## Why it meets the quality criteria

- **Official Support**: Maintained directly by Pizza Robot Studios (the maintainers of TensorFeed.ai).
- **Production Ready**: Live since early 2026, daily 100K+ KV operations, daily cron-driven data refreshes.
- **Active Maintenance**: 50+ commits/month at https://github.com/RipperMercs/tensorfeed.
- **Security**: Open auth on free tools (no PII handled). All paid endpoints use a separate x402 V2 payment surface (Coinbase exact scheme on Base mainnet) and are not exposed via the MCP surface. Worker enforces request validation, OFAC screening, rate limits, and chaos/circuit-breaker subsystems.
- **Reliability**: Cloudflare Workers + Pages, multi-cron data freshness, AFTA-certified self-attested at https://tensorfeed.ai/api/afta-certify/check?domain=tensorfeed.ai.
- **Community**: Listed in the canonical MCP registry as `ai.tensorfeed/mcp-server`, included in the Anthropic financial-services and life-sciences marketplaces, on Hugging Face as `tensorfeed/ai-ecosystem-daily`, and shipped with skill packages in `anthropics/skills` (PR #1114) and `openai/skills` (PR #405).

## Production usage examples

- **Cross-database CVE verification** (a single agent loop calls `get_cve_record` + `get_kev_catalog` + `get_epss_score` and returns a `confirmed_by` list): see the [Anthropic claude-cookbook example](https://github.com/anthropics/claude-cookbooks/pull/611) and the [OpenAI cookbook example](https://github.com/openai/openai-cookbook/pull/2683).
- **Hosted MCP integration**: see the [openai-agents-python example](https://github.com/openai/openai-agents-python/pull/3325) and the [claude-agent-sdk-python example](https://github.com/anthropics/claude-agent-sdk-python/pull/945).

## Notes

- Underlying data is mostly US Government public domain (SEC, BLS, FRED, MITRE, CISA, EIA) or CC0 (openFDA), with FIRST.org EPSS free for any use; commercial redistribution permitted with attribution preserved on every response.
- Open auth is appropriate here because the free tools serve only public, government-or-commons-licensed reference data with no per-user state.