### PR TITLE
Add NotFair

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
+| NotFair | Advertising | `https://notfair.co/api/mcp/google_ads` | OAuth2.1 | [NotFair](https://notfair.co) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |


### PR DESCRIPTION
Adding NotFair under the table. It's a hosted Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations (bids, budgets, negative keywords, ad copy), and execute approved changes via the official Google Ads API with a human-approval gate.

The endpoint is `https://notfair.co/api/mcp/google_ads` with full OAuth 2.1 (dynamic client registration supported), so it should slot in alongside the other OAuth 2.1 entries. Free tier available.

Inserted alphabetically between Notion and Octagon. Happy to adjust category, name, or position if you'd prefer something different — "Advertising" matched the existing Meta Ads by Pipeboard entry.