### PR TITLE
Add Packrift remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
+| Packrift | E-Commerce | `https://mcp.packrift.com/mcp` | Open | [Packrift MCP Server](https://packrift.com/pages/agents) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |


### PR DESCRIPTION
Adds Packrift's remote MCP server as an ecommerce entry.\n\nPackrift's endpoint is maintained by Packrift and provides packaging catalog search, pricing and inventory context, and cart URL creation for ecommerce packaging workflows.\n\nVerification:\n- Public repo: https://github.com/Packrift/packrift-mcp\n- Docs: https://packrift.com/pages/agents\n- Remote endpoint: https://mcp.packrift.com/mcp returned HTTP 200 text/event-stream during local check.\n\nAuthentication is listed as Open because the public catalog endpoint does not require user authentication.