### PR TITLE
Add Auxen — private AI infrastructure MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
+| Auxen | AI Infrastructure | `https://api.auxen.ai/mcp` | OAuth2.1 | [Auxen](https://auxen.ai) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |


### PR DESCRIPTION
Adds Auxen to the list — a remote MCP server for provisioning private AI model endpoints on dedicated GPU infrastructure (Llama 3.1, Qwen 2.5, Mistral, Gemma 2, Phi-3).

- **Endpoint:** `https://api.auxen.ai/mcp` (StreamableHTTP, stateless)
- **Auth:** OAuth 2.1 + PKCE with Dynamic Client Registration ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)). Discovery at `/.well-known/oauth-authorization-server`.
- **Tools (6):** `auxen_list_models`, `auxen_provision_model`, `auxen_get_instance_status`, `auxen_list_instances`, `auxen_destroy_instance`, `auxen_get_balance`. All annotated with `readOnlyHint` / `destructiveHint` per the MCP spec.
- **Maintainer:** Auxen — https://auxen.ai

Quality criteria check:

- ✅ Official: maintained by Auxen.
- ✅ Production-ready: in production with paying customers.
- ✅ Active maintenance: shipping weekly.
- ✅ Auth: OAuth 2.1 with DCR. API keys also accepted as a programmatic fallback for non-browser agents.
- ✅ Reliability: persistent endpoint behind Cloudflare; status at https://status.auxen.ai.

Privacy / Terms: https://auxen.ai/privacy | https://auxen.ai/terms
