### PR TITLE
Add Everstake (staking MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
+| Everstake | Crypto | `https://mcp.everstake.one` | Open | [Everstake](https://everstake.one) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |


### PR DESCRIPTION
 Adds the official Everstake remote MCP server — staking infrastructure data for 130+ blockchain networks.                       
   
  | Name | Category | URL | Authentication | Maintainer |                                                                         
  |------|----------|-----|----------------|------------|                                                                       
  | Everstake | Crypto | `https://mcp.everstake.one` | Open | [Everstake](https://everstake.one) |                                
                                                                                                                                  
  **About**                                                                                                                     
                                                                                                                                  
  Everstake is a non-custodial staking provider with $7B+ in secured assets across Ethereum, Solana, Aptos, Cosmos, and 130+ other
   networks. The MCP server exposes staking data to AI agents: live APY, uptime metrics, rewards calculator, custody integrations
  (Fireblocks, Coinbase Custody, BitGo, Anchorage), and partnership inquiry tools. Self-hostable from                             
  https://github.com/everstake/mcp or available hosted at `mcp.everstake.one`.
                                                                                                                                
  **Meets inclusion criteria**

  - **Official:** published and maintained by Everstake; verified `everstake.one` domain ownership; open-source at                
  https://github.com/everstake/mcp
  - **Production ready:** 99.98% uptime record, zero material slashing events, $7B+ in staked assets                              
  - **Security & compliance:** SOC 2 Type II, ISO/IEC 27001:2022, NIST CSF, GDPR, CCPA
  - **Active maintenance:** regularly updated, documented at https://docs.everstake.one/integrations/everstake-products/mcp-server
                                                                                                                                  
  **Placement:** alphabetically between Egnyte and Firefly.                                                                       
  **Category:** `Crypto` — follows the precedent set by Hive Intelligence. 