### PR TITLE
Add Dock

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
+| Dock | Productivity | `https://trydock.ai/api/mcp` | OAuth2.1 & API Key | [Dock](https://trydock.ai) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |


### PR DESCRIPTION
## Adding Dock to the list

**Server**: Dock — multi-agent workspace where humans and agents share workspaces, tables, docs, and threads.

- **Category**: Productivity
- **URL**: `https://trydock.ai/api/mcp`
- **Authentication**: OAuth 2.1 + API Key
- **Maintainer**: [Dock](https://trydock.ai)

### Quality criteria

- **Official Support**: Maintained by the Dock team at [try-dock-ai](https://github.com/try-dock-ai).
- **Production Ready**: Live at trydock.ai with paid Free / Pro / Scale tiers.
- **Active Maintenance**: Continuous deploys, public changelog at https://trydock.ai/changelog.
- **Security**: OAuth 2.1 with dynamic client registration + PKCE (S256). Discovery published at `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`. Bearer API keys also accepted via `Authorization: Bearer …`. Signed webhooks. Principal attribution on every write.
- **Reliability**: Hosted on Vercel + Neon with daily backups.
- **Community**: Docs at https://trydock.ai/docs/mcp, support@trydock.ai.

### Production use

Dock's hosted MCP gives AI agents a shared workspace (tables, docs, threads) that agents and humans can both read and write. Tool surface covers workspace CRUD, table rows, doc editing, threads, comments, webhooks, and billing.

### Notable

- Same endpoint accepts OAuth 2.1 (for ChatGPT / Claude custom connectors) and API keys (for code-editor agents on the stdio bridge).
- Per-principal authoring stamps so you can see which agent or human made every edit.
- Full REST + MCP + CLI parity — every MCP tool has a REST equivalent.