### PR TITLE
Add Artel — self-hosted MCP server for multi-agent coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| [Artel](https://github.com/NicolasPrimeau/artel) | Other | https://github.com/NicolasPrimeau/artel | OAuth 2.1 / API Key | NicolasPrimeau |
 
 
 # Remote MCP Installation Guide

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
-| [Artel](https://github.com/NicolasPrimeau/artel) | Other | https://github.com/NicolasPrimeau/artel | OAuth 2.1 / API Key | NicolasPrimeau |
+| [Artel](https://github.com/NicolasPrimeau/artel) | Other | `https://github.com/NicolasPrimeau/artel` | OAuth 2.1 / API Key | [NicolasPrimeau](https://github.com/NicolasPrimeau) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## Summary

Adds [Artel](https://github.com/NicolasPrimeau/artel) to the Other category.

- Self-hosted remote MCP server for multi-agent coordination
- Provides shared semantic memory, task management, agent-to-agent messaging, and session handoffs
- Full OAuth 2.1 support: dynamic client registration, authorization code with PKCE, and client credentials flow
- Also supports API key authentication
- Actively maintained, production-ready

## Table row added

| [Artel](https://github.com/NicolasPrimeau/artel) | Other | https://github.com/NicolasPrimeau/artel | OAuth 2.1 / API Key | NicolasPrimeau |

🤖 Generated with [Claude Code](https://claude.com/claude-code)