### PR TITLE
Add Misar.Blog — remote MCP server for AI-powered blogging (API Key auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
+| Misar.Blog | Blogging & Content | `https://www.misar.blog/api/mcp` | API Key | [Misar.Blog](https://www.misar.blog) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |


### PR DESCRIPTION
Adds [Misar.Blog](https://www.misar.blog) MCP server to the remote MCP server list.

- **URL**: `https://misarblog-mcp--misar.run.tools`
- **Category**: Blogging Platform
- **Auth**: API Key (from https://www.misar.blog/settings/api)
- **Maintainer**: [mrgulshanyadav](https://github.com/mrgulshanyadav/misarblog-mcp)
- **Tools**: 20 tools — create/publish articles, manage series, query analytics, comments, reactions, newsletter

Smithery listing: https://smithery.ai/servers/misar/misarblog-mcp