### PR TITLE
Add Mengram — memory layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 ## Remote MCP Server List
 
+| Mengram | Memory | `https://mengram.io/mcp` | API Key | [Mengram](https://mengram.io) |
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |


### PR DESCRIPTION
Adds [Mengram](https://mengram.io) — a remote MCP server providing AI agents with persistent memory.

- **Endpoint:** `https://mengram.io/mcp` (HTTP MCP, streamable)
- **Auth:** API Key (`Authorization: Bearer om-...`)
- **30 tools** (recall, remember, search, timeline, reflect, get_graph, dedup, …)
- **Three memory types** — semantic facts, episodic events, procedural workflows with success/failure-driven auto-evolution
- **Multi-tenant** — per-end-user isolation via `user_id` scoping
- **23 languages** — Cohere multilingual-v3 embeddings
- **Apache 2.0**, self-hostable, free tier (40 memories/mo, no card)

Repo: https://github.com/alibaizhanov/mengram