### PR TITLE
Add California Justice Watch (Legal & Public Records)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
+| California Justice Watch | Legal & Public Records | `https://cajusticewatch.com/api/mcp` | Open | [CA Justice Watch](https://cajusticewatch.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |


### PR DESCRIPTION
Adds California Justice Watch — a remote, open-auth MCP server exposing public California criminal-justice accountability databases.

- **URL:** `https://cajusticewatch.com/api/mcp`
- **Transport:** Streamable HTTP (MCP 2025-06-18)
- **Auth:** Open (public, read-only)
- **15 tools:** DAs (58), defenders (196), current judges (1,620), officer misconduct (1,500), CJP judicial discipline (247 records + semantic RAG over 250 CJP decision PDFs), POST decertifications (671)
- **Official MCP Registry:** `com.cajusticewatch/cajusticewatch` v0.1.0 ([listing](https://registry.modelcontextprotocol.io/v0/servers?search=cajusticewatch))
- **Source:** https://github.com/cajusticewatch/mcp-server
- **OpenAPI 3.1:** https://cajusticewatch.com/openapi.json

Meets the list's quality criteria: production-stable, active maintenance, all returned data is sourced public-record (cjp.ca.gov, post.ca.gov, court rosters, named press coverage).

Entry placed alphabetically between Buildkite and Canva.