### PR TITLE
Add PromptGuard Scan MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
+| PromptGuard Scan | Security | `https://promptguardscan.space/mcp` | API Key | [PromptGuard Scan](https://promptguardscan.space/?utm_source=awesome_remote_mcp_servers&utm_medium=directory&utm_campaign=sbl202605) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |


### PR DESCRIPTION
Adds PromptGuard Scan as a remote MCP server for LLM security testing. It uses Streamable HTTP with Bearer-token authentication after checkout and token claim.

Public docs: https://github.com/clauxel/prompt-injection-scanner-mcp
Endpoint: https://promptguardscan.space/mcp
Official Registry: space.promptguardscan/promptguardscan-mcp