### PR TITLE
Add click-to-mcp: Convert any CLI tool into a remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
+| click-to-mcp | Developer Tools | `https://click-to-mcp.dev` | Open | [Coding Dev Tools](https://github.com/Coding-Dev-Tools/click-to-mcp) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |


### PR DESCRIPTION
## click-to-mcp

Automatically converts any Click/Typer CLI into an MCP server. Supports both stdio and StreamableHTTP (remote) transports.

- **Repo**: https://github.com/Coding-Dev-Tools/click-to-mcp
- **Category**: Developer Tools
- **URL**: Configurable per-tool (users set the port/host)
- **Auth**: Open (local dev) / configurable for production

click-to-mcp enables developers to expose their existing CLI tools as remote MCP servers with zero code changes, making them accessible to any MCP-compatible AI client.

🤖🤖🤖