### PR TITLE
Add Verdigraph — paid hosted MCP for agent-to-agent compute routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |
+| Verdigraph | Compute Routing | `https://verdigraph-mcp.hartjustin6.workers.dev/mcp` | OAuth2.1 | [Viridis](https://github.com/viridis-security/verdigraph-neurogenesis) |
 | VibeMarketing | Social Media | `https://vibemarketing.ninja/mcp` | OAuth2.1 | [VibeMarketing](https://vibemarketing.ninja) |
 | Webflow | CMS | `https://mcp.webflow.com/sse` | OAuth2.1 | [Webflow](https://webflow.com) |
 | Wix | CMS | `https://mcp.wix.com/sse` | OAuth2.1 | [Wix](https://wix.com) |


### PR DESCRIPTION
Adding Verdigraph to the Remote MCP Server List.

**What it is:** Hosted, OAuth 2.1 + PKCE authenticated MCP server. 16 tools for picking the cheapest reliable compute profile for a task, managing long-lived developmental agents, and emitting an immutable evaluation ledger. Pay per call in USD via Stripe Checkout.

**Differentiator:** First hosted MCP with a binding 25% conservation revenue share — enforced at the database level (CHECK constraint on `conservation_payouts`), monthly Cloudflare cron writes payouts to a public auditable ledger.

**Quality criteria compliance:**
- Production ready ✓ Live at https://verdigraph-mcp.hartjustin6.workers.dev (Cloudflare Workers)
- Active maintenance ✓ Maintained by Viridis LLC
- Security ✓ OAuth 2.1 + PKCE with dynamic client registration
- Reliability ✓ 73/73 tests passing including atomic credit-ledger and replay-isolation suites

**Discovery surfaces:**
- SEP-1960 manifest: https://verdigraph-mcp.hartjustin6.workers.dev/.well-known/mcp
- SEP-1649 server card: https://verdigraph-mcp.hartjustin6.workers.dev/.well-known/mcp/server-card.json
- Listed in the official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=verdigraph

Repository: https://github.com/viridis-security/verdigraph-neurogenesis