### PR TITLE
Add Ultiplace (B2B Events)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
+| Ultiplace | B2B Events | `https://www.ultiplace.com/api/mcp` | OAuth2.1 & API Key | [Ultiplace](https://www.ultiplace.com/ai/mcp) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |


### PR DESCRIPTION
## Summary

Adds **Ultiplace** to the Remote MCP Server List.

Ultiplace is a French B2B platform for virtual trade shows and physical event directory, accessible via a remote MCP server.

## Server details

| Field | Value |
|---|---|
| Name | Ultiplace |
| Category | B2B Events |
| URL | \`https://www.ultiplace.com/api/mcp\` |
| Transport | Streamable HTTP (protocol 2024-11-05) |
| Auth | OAuth 2.0 PKCE & API Key |
| Tools | 19 (salon, stand, conference, exhibitor, team, analytics, directory) |
| Docs | https://www.ultiplace.com/ai/mcp |
| Status page | https://www.ultiplace.com/ai/status |
| Official MCP Registry | \`io.github.Realitim/ultiplace-mcp\` ([verify](https://registry.modelcontextprotocol.io/v0.1/servers?search=ultiplace)) |

## Quality criteria

- **Security**: OAuth 2.0 PKCE flow, scoped access tokens (\`salon:read\`, \`salon:write\`, \`directory:read\`, etc.), confidential clients for Claude Desktop / GPT Store / Mistral Le Chat already provisioned.
- **Reliability**: Hosted on Vercel Frankfurt + Firebase Europe. Status page at \`/ai/status\`.
- **Community**: Documented at \`/ai/mcp\`, OpenAPI 3.1 spec public at \`/openapi.json\`.

Thanks for maintaining this list.

Made with [Cursor](https://cursor.com)