### PR TITLE
Add CrawlConsole remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
+| CrawlConsole | SEO & Backlink Analysis | `https://mcp.crawlconsole.com/mcp` | OAuth2.1 / API Key | [CrawlConsole](https://crawlconsole.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |


### PR DESCRIPTION
Adds CrawlConsole's production remote Streamable HTTP MCP endpoint.\n\nCrawlConsole provides backlink analysis for AI agents, including authority metrics, referring domains, competitor link gaps, and page-level backlink research workflows. The hosted endpoint supports OAuth 2.1 and Agent API key bearer auth, and is already published in the official MCP Registry as `com.crawlconsole/crawlconsole`.