### PR TITLE
Add CausalLayer — deterministic AI liability attribution (remote MCP …

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
+| CausalLayer | AI Governance | `https://causallayer-mcp-demo.zykm9qkk7j.workers.dev/mcp` | Open | [FaultKey](https://faultkey.com) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |


### PR DESCRIPTION
…server)

CausalLayer is a remote MCP server that provides deterministic AI liability attribution. Given a structured incident, it returns a CausalCertificateV1: a signed, hash-chained, Bitcoin-anchored receipt allocating fault between AI vendor, deployer, and end-user.

- Category: AI Governance
- Auth: Open (no API key required for demo)
- URL: https://causallayer-mcp-demo.zykm9qkk7j.workers.dev/mcp
- Maintainer: FaultKey (https://faultkey.com)
- Source: https://github.com/smq9sn5jck-coder/causallayer-mcp