### PR TITLE
Add Commit — supply chain risk scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |
 | Context Awesome | Specialised Dataset | `https://www.context-awesome.com/api/mcp` | Open | [Context Awesome](https://www.context-awesome.com/) |
+| Commit | Security | `https://poc-backend.amdal-dev.workers.dev/mcp` | Open | [Commit](https://getcommit.dev) |
 | DeepWiki | RAG-as-a-Service | `https://mcp.deepwiki.com/sse` | Open | [Devin](https://devin.ai/) |
 | Exa Search | Search | `https://mcp.exa.ai/mcp` | Open | [Exa](https://exa.ai) |
 | Hugging Face | Software Development | `https://hf.co/mcp` | Open | [Hugging Face](https://huggingface.co) |


### PR DESCRIPTION
Adds [Commit](https://getcommit.dev) (proof-of-commitment) to the remote MCP server list.

**Server details:**

- **Name:** Commit
- **Category:** Security
- **URL:** `https://poc-backend.amdal-dev.workers.dev/mcp` (Streamable HTTP)
- **Authentication:** Open (no auth required)
- **GitHub:** https://github.com/piiiico/proof-of-commitment

**What it does:**

Supply chain risk scoring for npm, PyPI, Cargo, and Go packages. 9 tools that score dependencies on behavioral signals — publisher concentration, release consistency, longevity — to help developers assess supply chain risk before adding dependencies.