### PR TITLE
feat: add Longbridge MCP (official brokerage, Finance, OAuth 2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
+| Longbridge | Finance / Brokerage | `https://openapi.longbridge.com/mcp` | OAuth2.1 | [Longbridge](https://github.com/longbridge/longbridge-mcp) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |


### PR DESCRIPTION
## Add Longbridge MCP

**Name:** Longbridge MCP  
**Category:** Finance / Brokerage  
**URL:** `https://openapi.longbridge.com/mcp`  
**Auth:** OAuth2.1 (RFC 9728)  
**GitHub:** https://github.com/longbridge/longbridge-mcp  

### About

Longbridge is a licensed securities broker. The Longbridge MCP is the **official** server maintained by Longbridge Securities, providing 133 tools for:

- Real-time quotes (US / HK / A-share / Singapore)
- Options chains, warrants, derivatives
- Trading (orders, positions, portfolio management)
- Fundamentals, earnings, corporate events
- IPO calendar, DCA strategies, alerts

### Quality Criteria Checklist

- [x] **Official Support** — maintained by Longbridge Securities
- [x] **Production Ready** — stable, used by Longbridge app users
- [x] **Active Maintenance** — regular updates (latest: v0.3.2)
- [x] **Security** — OAuth 2.1 with RFC 9728 Authorization Server Metadata
- [x] **Reliability** — backed by Longbridge's production infrastructure
- [x] **Remote** — Streamable HTTP transport at `https://openapi.longbridge.com/mcp`