### PR TITLE
Add agent-tools-mcp to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| agent-tools-mcp | Discovery / x402 Services | `https://agent-tools.cloud/mcp-discovery/` | Open | [agent-tools.cloud](https://agent-tools.cloud) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
Adds [agent-tools-mcp](https://github.com/JoursBleu/agent-tools-mcp) to the Remote MCP Server List.

A free remote (streamable-http) MCP server for discovering and calling x402 paid services. Indexes 2,300+ services from public x402 indexes with quality signals (confidence + 30-day on-chain transaction volume). Agents search by intent and filter by price/chain.

- **Endpoint**: https://agent-tools.cloud/mcp-discovery/  (streamable-http, free, no auth)
- **Repo**: https://github.com/JoursBleu/agent-tools-mcp
- **PyPI**: https://pypi.org/project/agent-tools-mcp/
- **MCP Registry**: io.github.JoursBleu/agent-tools-mcp (isLatest=true)
- **Category**: Discovery / x402 Services