### PR TITLE
Add TideTurtle remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
+| TideTurtle | Weather/Geo | `https://tideturtle.com/mcp` | Open | [TideTurtle](https://tideturtle.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |


### PR DESCRIPTION
Adds **TideTurtle** to the Remote MCP Server List.

- **Name:** TideTurtle
- **Category:** Weather/Geo (tide times + tide charts)
- **URL:** `https://tideturtle.com/mcp`
- **Authentication:** Open (no key, no signup)
- **Maintainer:** [TideTurtle](https://tideturtle.com)

What it does: provides AI agents with tide data for 1,414 coastal places worldwide. Three tools — `list_places`, `get_place`, `tides_nearby`. Hosted on Cloudflare Workers.

Quality criteria check:
- ✅ Remote-only HTTP endpoint
- ✅ Stable production URL
- ✅ Documented at https://tideturtle.com/developers
- ✅ OpenAPI 3 spec at /api/v1/openapi.json
- ✅ CORS-open
- ✅ Data sources: NOAA, UK Environment Agency, BSH (Germany), Open-Meteo Marine (per-source accuracy at /methodology)