### PR TITLE
Add Auxen — managed private LLM inference (OAuth 2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
+| Auxen | Developer Tools | `https://api.auxen.ai/mcp` | OAuth2.1 | [Auxen](https://auxen.ai) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |


### PR DESCRIPTION
Adds [Auxen](https://auxen.ai) to the **Remote MCP Server List** under **Developer Tools**.

Auxen is a managed inference platform that provisions private AI model endpoints on dedicated GPUs (Llama, Qwen, Mistral, Gemma, Phi-3, Mixtral). The hosted MCP server at `api.auxen.ai/mcp` lets AI clients provision, manage, and tear down model instances via natural language.

**Quality criteria (per CONTRIBUTING):**

- ✅ **OAuth 2.1 + PKCE-S256** — verified via discovery endpoints
- ✅ **Dynamic Client Registration (RFC 7591)** — `POST /oauth/register` returns 201 with a fresh client_id
- ✅ **RFC 8414 discovery** — `/.well-known/oauth-authorization-server` returns full metadata including refresh_token grant
- ✅ **RFC 9728 protected-resource metadata** — both `/.well-known/oauth-protected-resource` and the path-scoped variant
- ✅ **MCP spec 2025-06-18** — 10 tools registered with proper `readOnlyHint` / `destructiveHint` / `idempotentHint` annotations
- ✅ **Production-ready** — live and serving traffic, not a beta

**Quick verification:**

```
$ curl -i https://api.auxen.ai/.well-known/oauth-authorization-server
HTTP/1.1 200 OK
{
  "issuer": "https://api.auxen.ai",
  "authorization_endpoint": "https://api.auxen.ai/oauth/authorize",
  "token_endpoint": "https://api.auxen.ai/oauth/token",
  "registration_endpoint": "https://api.auxen.ai/oauth/register",
  "code_challenge_methods_supported": ["S256"],
  ...
}
```

**Repo (server docs + tool inventory):** https://github.com/auxen-ai/mcp-server
**Production:** https://auxen.ai