### PR TITLE
Add Fillin — remote search MCP server for post-cutoff knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
-| Fillin | Search | `https://fillin.glyphapi.dev/mcp` | Open / API Key | [Fillin](https://fillin.glyphapi.dev) |
+| Fillin | Search | `https://fillin.glyphapi.dev/mcp/` | Open / API Key | [Fillin](https://fillin.glyphapi.dev) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
+| Fillin | Search | `https://fillin.glyphapi.dev/mcp` | Open / API Key | [Fillin](https://fillin.glyphapi.dev) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |


### PR DESCRIPTION
Adds **Fillin** to the Remote MCP Server List. Fillin is a streamable-HTTP MCP server that closes the gap between an LLM's training cutoff and now — fresh, vector-indexed corpus of CVEs (NVD+GHSA+OSV), arXiv+HF Daily+bioRxiv papers, frontier-lab announcements, and prediction-market prices (Polymarket+Kalshi+Manifold+Metaculus).

- URL: `https://fillin.glyphapi.dev/mcp` (streamable HTTP)
- Free probe (no auth, 1/IP/day): `POST https://fillin.glyphapi.dev/v1/probe`
- Auth: **Open** (free probe + free tools `fillin_health` / `fillin_stats`), or **API Key** (`Authorization: Bearer fk_live_…`, funded via `POST /v1/billing/checkout` → Stripe Checkout)
- Manifest: https://fillin.glyphapi.dev/.well-known/agents.json
- Also published to the official MCP Registry as `io.github.artchristech/fillin`

## Quality criteria

- **Production ready** — deployed on dedicated infra, 73k+ docs indexed
- **Active maintenance** — ingestion every 30 min, daily slice snapshots
- **Security** — Stripe (restricted key, Checkout Sessions Write only) + on-chain x402 (EIP-191 personal_sign over server-minted nonce)
- **Reliability** — `/v1/health` returns 200 with `ingest_lag_seconds` freshness signal

## Verify without paying

```
curl https://fillin.glyphapi.dev/v1/health
curl -X POST https://fillin.glyphapi.dev/v1/probe \
  -H 'content-type: application/json' \
  -d '{"query":"mixture of experts","cutoff":"2024-04-01"}'
```