### PR TITLE
Add Lumnix - E-commerce research MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
+| Lumnix | E-Commerce | `https://lumnix.dev/api/mcp` | API Key | [Molt Studios](https://lumnix.dev) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |


### PR DESCRIPTION
## Lumnix — Remote E-Commerce MCP Server

19 tools for Amazon, Alibaba & AliExpress product research, supplier vetting, and FBA profit calculations.

- **Server URL:** `https://lumnix.dev/api/mcp` (Streamable HTTP)
- **Auth:** API Key (Bearer token)
- **npm:** https://www.npmjs.com/package/lumnix
- **GitHub:** https://github.com/moltstudios/lumnix-mcp
- **Website:** https://lumnix.dev
- **Free tier:** 10 calls/month

Added to the Remote MCP Server List table in the E-Commerce category.