### PR TITLE
Add Pictify to the Remote MCP Server List (Design)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Parallel Search MCP | Web Search | `https://search-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Peek.com | Other | `https://mcp.peek.com` | Open | [Peek.com](https://peek.com) |
+| Pictify | Design | `https://mcp.pictify.io` | OAuth2.1 | [Pictify](https://pictify.io) |
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |


### PR DESCRIPTION
Adds **Pictify** to the Remote MCP Server List in the Design category, placed between Peek.com and Plaid.

| Name | Category | URL | Authentication | Maintainer |
|------|----------|-----|----------------|------------|
| Pictify | Design | `https://mcp.pictify.io` | OAuth2.1 | [Pictify](https://pictify.io) |

**What it does:** Image, GIF & PDF rendering layer for AI agents. 22 tools that generate OG images, social cards, screenshots, animated GIFs, and PDFs from HTML/CSS, URLs, or reusable templates (Fabric + Handlebars engines). Batch render up to 100 personalized assets and built-in A/B experiments.

**Quality criteria check (from CONTRIBUTING)**
- ✅ Remote / hosted (https://mcp.pictify.io)
- ✅ Transport: Streamable HTTP
- ✅ Auth: OAuth2.1-compatible (client_id + client_secret) — wired up for Claude.ai custom connector
- ✅ Production: live and serving requests
- ✅ Stdio fallback for self-host: `npx -y @pictify/mcp-server`
- ✅ Repo: https://github.com/pictify-io/mcp (MIT)
- ✅ npm: https://www.npmjs.com/package/@pictify/mcp-server (v1.2.0)
- ✅ Glama indexed: https://glama.ai/mcp/servers/pictify-io/mcp

**Claude.ai connector install**
1. Settings → Connectors → Add custom connector
2. URL: `https://mcp.pictify.io`
3. Advanced: Client ID `pictify`, Client Secret = your Pictify API token