### PR TITLE
Add MyAITwin (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
+| MyAITwin | Memory | `https://myaitwin.lutolearn.com/mcp` | OAuth2.1 | [Luto](https://myaitwin.lutolearn.com/) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adds MyAITwin, a remote MCP server by Luto.

Category: Memory. URL: https://myaitwin.lutolearn.com/mcp. Auth: OAuth 2.1 (PKCE + Dynamic Client Registration). Company-maintained, production, free during early access. Also live in the Official MCP Registry as com.lutolearn/myaitwin.

A personal RAG database and semantic search you build from chat: store your knowledge, voice, and skills, retrieve them with the source cited, and create work that sounds like you. 19 tools.