### PR TITLE
feat: add Gapup MCP — 185 agent-payable C-suite tools (x402 USDC/EURC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
+| Gapup MCP | Data Analysis | `https://mcp.gapup.io/mcp` | API Key | [Gapup](https://hub.gapup.io/agents-api) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |


### PR DESCRIPTION
## Adding Gapup MCP to Data Analysis

Hosted MCP server with **185 agent-payable C-suite tools** — SEC filings, sanctions/KYC, clinical evidence, ESG, EU AI Act, real-estate underwriting, ~50 more verticals.

| Field | Value |
|-------|-------|
| URL | `https://mcp.gapup.io/mcp` (MCP Streamable HTTP) |
| Auth | API Key (Bearer) |
| Free tier | 100 calls/month, no credit card |
| Paid | x402 USDC/EURC, Base + Optimism, $0.05-$0.30 per call |
| License (manifests + docs) | MIT |
| Repo | https://github.com/getgapup/gapup-mcp-public |

### Quality criteria ✓
- **Official**: Maintained by Gapup (agents@gapup.io)
- **Production**: Live at mcp.gapup.io, Cloudflare WAF, Sentry, rate-limit, circuit-breaker
- **Active**: v0.2.3 pushed to MCP Registry today
- **Security**: API key, `/.well-known/security.txt` (RFC 9116)
- **Already listed**: Smithery (verified), Glama, MCP Registry officiel (`io.github.getgapup/gapup-mcp`), Cursor Directory, MCPBundles, HuggingFace Spaces, mcp.market

Pay-per-call so consumers only pay for what they consume — no subscription gating.

Happy to provide additional details. Thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)