### PR TITLE
Add Sanka MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Google GKE | Developer Tools | `https://container.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/kubernetes-engine/docs/reference/mcp) |
 | Google Maps | Mapping | `https://mapstools.googleapis.com/mcp` | API Key | [Google](https://developers.google.com/maps/ai/grounding-lite/reference/mcp) |
 | HubSpot | CRM | `https://app.hubspot.com/mcp/v1/http` | API Key | [HubSpot](https://hubspot.com) |
+| Sanka | CRM | `https://mcp.sanka.com/mcp` | OAuth2.1 | [Sanka](https://sanka.com) |
 | Needle | RAG-as-a-service | `https://mcp.needle-ai.com/mcp` | API Key | [Needle](https://needle-ai.com) |
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |


### PR DESCRIPTION
## Summary
- Add Sanka MCP Server to the relevant MCP server list/category
- Link to the public repository: https://github.com/sankaHQ/sanka-mcp

## Notes
- Sanka MCP is a hosted remote MCP server for Sanka API, connecting AI agents to CRM and back-office workflows.
- The hosted endpoint is documented in the public repository README.

## Verification
- Checked for an existing Sanka entry before adding this one.
- Ran `git diff --check` locally for this documentation-only change.
