### PR TITLE
Add RaiseKit (CRM for VC fundraising)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
+| RaiseKit | CRM | `https://raisekit.co/api/mcp` | API Key | [RaiseKit](https://raisekit.co) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |


### PR DESCRIPTION
Adds **RaiseKit** to the Remote MCP Server List.

- **Name:** RaiseKit
- **Category:** CRM
- **URL:** `https://raisekit.co/api/mcp`
- **Authentication:** API Key (bearer token from raisekit.co/settings/agents)
- **Maintainer:** [RaiseKit](https://raisekit.co)

RaiseKit is a CRM and fundraising platform built for VC-backed founders. The remote MCP server exposes ~40 tools across pipeline management (rounds, opportunities, stages, touches), conversation (drafts, scheduled sends with human approval), artifacts (decks, term sheets), and VC intelligence. Production-ready, hosted, with stable authentication.

Quality criteria check:
- ✅ Officially maintained by RaiseKit
- ✅ Production-ready (live at raisekit.co)
- ✅ Active maintenance
- ✅ API Key authentication
- ✅ Stable uptime on Vercel