### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Webflow | CMS | `https://mcp.webflow.com/sse` | OAuth2.1 | [Webflow](https://webflow.com) |
 | Wix | CMS | `https://mcp.wix.com/sse` | OAuth2.1 | [Wix](https://wix.com) |
 | WebZum | Website Hosting | `https://webzum.com/api/mcp` | Open | [WebZum](https://webzum.com) |
+| YIELD INTELLIGENCE | Finance | `https://api.intuitek.ai/yield/mcp` | Open | [IntuiTek¹](https://thebrierfox.github.io/yield-intelligence/) |
 | Simplescraper | Web Scraping | `https://mcp.simplescraper.io/mcp` | OAuth2.1 | [Simplescraper](https://simplescraper.io) |
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
 | Zenable | Security | `https://mcp.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Finance category.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

This is a remote MCP server — no local installation needed, connect directly by URL.
