### PR TITLE
Add Yarrow — I-Ching oracle (hosted HTTP MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| Yarrow | Reflection | `https://yarrow-oracle.shaozhengkun.workers.dev/mcp` | Open | [Yarrow](https://github.com/shaozhengkun123/yarrow) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
# Add Yarrow — I-Ching oracle (hosted HTTP MCP)

Adding **Yarrow** to the list:

> **[@shaozhengkun/yarrow](https://github.com/shaozhengkun123/yarrow)** — An I-Ching (Book of Changes / 周易) oracle. Cast hexagrams, look up classical sources (杨天才, 朱熹《周易本义》, 断易天机), and get a Wilhelm/Baynes-style reflection. Bilingual (en/zh). Hosted HTTP MCP + iOS app.

## Quick facts

- **Endpoint**: `https://yarrow-oracle.shaozhengkun.workers.dev/mcp` (streamable HTTP MCP)
- **Tools**: `cast_hexagram`, `lookup_hexagram`, `divine`
- **Quota**: 30 readings/day per anonymous caller (device_id or IP)
- **Auth**: none required
- **Source**: MIT, https://github.com/shaozhengkun123/yarrow
- **Companion iOS app**: https://apps.apple.com/app/id6773156209

## Why it's worth listing

Most divination MCP servers are toy implementations. Yarrow includes the full classical commentary apparatus (modern translations of 卦辞/爻辞, 朱熹's 周易本义 original Chinese, 断易天机 historical anecdotes, 白话 plain-language notes) and is bilingual. The Worker enforces explicit boundaries against fortune-telling, medical, legal, and financial advice — the system prompt is open source and visible in the repo.

It also ships as a Claude Code / Codex plugin via this repo's `.claude-plugin/marketplace.json`, so users can `claude plugin marketplace add https://github.com/shaozhengkun123/yarrow` and get the skill + MCP installed in one step.

## Test

```bash
curl -s -X POST https://yarrow-oracle.shaozhengkun.workers.dev/mcp \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools[].name'
```

Expected: `"cast_hexagram"`, `"lookup_hexagram"`, `"divine"`.
