### PR TITLE
Add Tempreon — portable knowledge layer for AI (Memory category, OAuth 2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
-| ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
+| Tempreon | Memory | `https://api.tempreon.com/functions/v1/tempreon-mcp/mcp` | OAuth2.1 | [Tempreon](https://tempreon.com) |
+ Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |


### PR DESCRIPTION
Adding Tempreon, a remote MCP server that brings persistent identity and accumulated knowledge across every AI tool you use.

## What Tempreon is

Tempreon is a portable knowledge layer about you, connected to AI tools via MCP. It learns from how you actually work — voice, decisions, instincts, accumulated knowledge — and carries that context across every LLM. Person-centered, not company-centered. Where most memory systems store and recall, Tempreon learns and grows.

## Quality criteria checklist

- **Official Support**: Maintained by Briggs Ventures, LLC (d/b/a Tempreon)
- **Production Ready**: V1.0.0 launched 2026-05-26
- **Active Maintenance**: Active product development
- **Security**: OAuth 2.1 with PKCE + dynamic client registration (RFC 7591); per-account database-level isolation; data never used to train AI models ([AI Use Policy](https://tempreon.com/legal/ai-policy))
- **Reliability**: Hosted on production infrastructure
- **Community**: Documentation, support, and active community channels

## Server details

- **Name**: Tempreon
- **Category**: Memory
- **URL**: `https://api.tempreon.com/functions/v1/tempreon-mcp/mcp`
- **Authentication**: OAuth 2.1 (with PKCE + dynamic client registration)
- **Maintainer**: [Tempreon](https://tempreon.com) (Briggs Ventures, LLC)
- **Public repo**: https://github.com/Tempreon/tempreon-mcp
- **Documentation**: https://tempreon.com/support/docs/bridges

## Supported clients

Fully tested: Claude Desktop, Claude Code, Codex (ChatGPT Mac app/IDE/CLI), ChatGPT (web + desktop). Community-tested: Cursor. Universal compatibility for any MCP-capable client via OAuth flow.