### PR TITLE
Add AgentScrape to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AgentScrape | Web Scraping | `https://agent-scrape.healingsunhaven.workers.dev/mcp` | x402 (USDC on Base) | [HSH Intelligence](https://github.com/hshintelligence) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
## What is AgentScrape

[AgentScrape](https://agent-scrape.healingsunhaven.workers.dev) is a pay-per-call web scraping service for AI agents, built around the [x402 protocol](https://www.x402.org) on Base USDC. Agents pay per call autonomously — no signup, no API keys.

## Authentication: x402

This is a remote MCP server that uses the x402 payment protocol (HTTP 402 Payment Required + USDC settlement on Base mainnet) instead of OAuth or API keys. Listed under `Open / API Key` precedent that exists in the table (e.g. AWS Knowledge: Open, BGPT: Open / API Key).

## Why it qualifies

- **Remote MCP server**: Live at https://agent-scrape.healingsunhaven.workers.dev/mcp (Streamable HTTP transport)
- **Production**: 6 tools (scrape, extract via Groq+Llama 4, screenshot, metadata, session, workflow) live on Base mainnet
- **Already vetted**: Listed on punkpeye/awesome-mcp-servers (PR #6837 merged), Glama with License A / Quality A grades, Smithery 82/100, mcp.so
- **Open source**: MIT license at https://github.com/hshintelligence/agent-scrape
- **Standards-compliant**: A2A Agent Card at /.well-known/agent.json, OpenAPI 3.1, llms.txt, IPFS-pinned x402 manifest, Schema.org Service JSON-LD

Thanks for maintaining the canonical remote MCP list.