### PR TITLE
Add Doxa MCP: Christian AI for any question, in any season

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
+| Doxa | Faith / Bible | `https://doxa.app/mcp/v1` | Open / API Key | [The Doxa Way](https://doxa.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |


### PR DESCRIPTION
Adds Doxa MCP to the Remote MCP Server List under a new "Faith / Bible" category.

## What it is
Doxa MCP is a Christian AI for any question, in any season. Truth that points to Jesus and to real relationships. Three tools: doxa_encourage, doxa_scripture, doxa_way_movement.

For anyone: the believer growing, the seeker searching, the curious, the hurt. Built for the good seasons (loving God more, discerning calling, real testimonies of His goodness) and the hard ones (doubt, grief, religious trauma, deconstruction, apologetics).

## Why it fits the list
- **Production ready**: Live at https://doxa.app/mcp/v1, served by Supabase Edge Functions
- **Independently evaluated**: 5/5 on the faith.tools Christian-AI rubric, including the crisis-handling test. Public transcripts.
- **Bible**: 31,000+ verses across two public-domain translations (BSB and WEB)
- **Security**: Supports both hosted and BYOL (X-Anthropic-Key header)
- **Community**: Anthropic MCP Registry v1.0.3, npm (@thedoxaway/mcp-client), Smithery, Cursor Directory

## Links
- Live endpoint: https://doxa.app/mcp/v1
- Schema repo: https://github.com/The-Doxa-Way/doxa-mcp-schema
- Official MCP Registry listing: io.github.TheDoxaWay/doxa-mcp