### PR TITLE
Add FutureProof AEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| FutureProof AEO | Marketing | `https://ai.futureproof.work/.netlify/functions/mcp` | API Key | [FutureProof](https://ai.futureproof.work) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
Adds **FutureProof AEO** — a remote MCP server that tracks how a brand appears across ChatGPT, Claude, Gemini, and Perplexity. Six tools: visibility tracking, GEO audit, competitor comparison, per-question breakdown, report retrieval, brand list.

- Streamable HTTP, no install
- API Key auth (bearer `fp_live_...`) — plus a free-tier endpoint with no signup at `/.netlify/functions/mcp-free` (5 calls/day, 15 questions/day per IP)
- Production: backed by FutureProof.work
- Discovery manifest: https://ai.futureproof.work/.well-known/mcp.json
- Docs: https://ai.futureproof.work/docs/mcp

Inserted in alphabetical position under the existing remote server table.