### PR TITLE
Add KRTR — pre-diligence AI for VC firms, investors, and founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Invidio | Video Platform | `https://mcp.invideo.io/sse` | OAuth2.1 | [Invidio](https://invideo.io/) |
 | Jam | Software Development | `https://mcp.jam.dev/mcp` | OAuth2.1 | [Jam.dev](https://jam.dev/) |
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
+| KRTR | Venture Capital | `https://www.krtr.ai/api/mcp` | OAuth2.1 | [KRTR](https://krtr.ai) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |


### PR DESCRIPTION
## Adding KRTR to the list

**Server**: KRTR
**URL**: `https://www.krtr.ai/api/mcp`
**Category**: Venture Capital
**Authentication**: OAuth 2.1 (with Dynamic Client Registration)

KRTR is a pre-diligence intelligence layer for founders, investors, and VC firms — multi-agent pitch analysis, deal flow management, attributed signals, and AI-synthesized deal memos. The MCP is role-aware (different toolkit for founder vs investor vs firm member) and tuned per major MCP client (Claude, ChatGPT, Cursor, Grok, Gemini).

**Quality criteria check**:
- ✅ Official: Maintained by KRTR, Inc. (krtr.ai)
- ✅ Production-ready: v2.5 shipped to users this week
- ✅ Active maintenance: Continuous deployment via Vercel
- ✅ Security: OAuth 2.1 with Dynamic Client Registration
- ✅ Listed on the official MCP Registry: \`ai.krtr/krtr\`
- ✅ Listed on Smithery: \`krtr/krtr\`

Thanks for maintaining this list!