### PR TITLE
Add YesHello remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| YesHello | Digital Business Cards | `https://yeshello.app/api/mcp` | OAuth2.1 | [YesHello](https://yeshello.app) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
Digital business cards, lead capture forms, and service listings.

- URL: https://yeshello.app/api/mcp
- Auth: OAuth 2.1 (CIMD + PKCE S256)
- 63 tools
- Streamable HTTP

https://github.com/yeshello-app/mcp