### PR TITLE
Add Context Cloud — shared team memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |
+| Context Cloud | Memory | `https://api.contextcloud.pro/mcp/protocol` | OAuth2.1 | [Context Cloud](https://contextcloud.pro) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |


### PR DESCRIPTION
Context Cloud is the only remote MCP server with shared team workspaces, typed knowledge chunks (decision/finding/convention/state), RBAC, and cross-tool support. OAuth 2.1 authenticated. Published on MCP Registry as io.github.abhinavala/context-cloud. Website: contextcloud.pro