### PR TITLE
Add UnifAPI remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
+| UnifAPI | Data Analysis | `https://mcp.unifapi.com` | OAuth2.1 / API Key | [UnifAPI](https://unifapi.com) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |
 | VibeMarketing | Social Media | `https://vibemarketing.ninja/mcp` | OAuth2.1 | [VibeMarketing](https://vibemarketing.ninja) |


### PR DESCRIPTION
## Summary

Adds UnifAPI to the remote MCP server list.

UnifAPI is a hosted Streamable HTTP MCP server for public-data workflows across social, search, scrape, news, creator research, and KOL pricing use cases.

## Quality criteria

- Official server URL: `https://mcp.unifapi.com`
- Authentication: OAuth2.1 with API-key fallback
- Maintainer: UnifAPI
- Documentation: https://docs.unifapi.com/mcp
- Server metadata repo: https://github.com/unifapi-agent/unifapi-mcp-server