### PR TITLE
Add SocialDataX Kuaishou MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
+| SocialDataX Kuaishou | Social Media | `https://mcp.52choujiang.com/kuaishou/mcp` | API Key | [SocialDataX](https://socialdatax.com) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |


### PR DESCRIPTION
Adds the hosted SocialDataX Kuaishou remote MCP endpoint.\n\n- Endpoint: https://mcp.52choujiang.com/kuaishou/mcp\n- Authentication: API Key\n- Maintainer/product site: https://socialdatax.com\n- Public repo: https://github.com/DevinChen2014/kuaishou-mcp\n- Official MCP Registry: com.52choujiang/kuaishou-insights\n- Glama connector: https://glama.ai/mcp/connectors/com.52choujiang/kuaishou-insights