### PR TITLE
Add BuildCalc API to the Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
+| BuildCalc API | Construction | `https://api.buildcalcapi.dev/mcp` | API Key | [BuildCalc API](https://buildcalcapi.dev) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |


### PR DESCRIPTION
Adds [BuildCalc API](https://buildcalcapi.dev) — a vertical construction data API for AI agents — as the first Construction entry in the Remote MCP Server List.

Streamable HTTP at `https://api.buildcalcapi.dev/mcp`, API key auth. ~105 MCP tools across 5 federated verticals: 81 building-code-grounded calculators (concrete, framing, HVAC sizing, NEC electrical, IRC stairs); 937 IRC/IBC/NEC/IECC/IPC code sections with full-text search; federal cost data (BLS PPI/OEWS/QCEW + Census BPS); 43,400+ certified product SKUs (ENERGY STAR, ICC-ES ESR, NFRC, EPA WaterSense); 15 project benchmarks. 96% certified-grade from federal sources. Free tier 1,000 req/month.

Also listed on the official Anthropic MCP Registry (`dev.buildcalcapi/server`) and Smithery (`buildcalcapi/server`).