### PR TITLE
Add avots (remote media-generation MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
+| avots | Media Generation | `https://mcp.avots.ai/` | API Key | [avots.ai](https://avots.ai) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |


### PR DESCRIPTION
Adds **avots** to the Remote MCP Server List.

- **URL:** `https://mcp.avots.ai/` (Streamable HTTP, MCP spec 2025-06-18)
- **Auth:** API Key (Bearer token)
- **What it does:** image, video, audio, face-swap, talking-avatar generation and chat across 300+ AI models, billed from one balance.
- **Docs / source:** https://github.com/avotsai/avots-mcp

Meets the quality criteria: real hosted server, API-Key auth, public docs with a tool reference. Inserted alphabetically.