### PR TITLE
Add The Stall — remote market data MCP server (28 tools, x402 pay-per-call)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
+| The Stall | Market Data | `https://the-stall.intuitek.ai/mcp` | Open | [IntuiTek¹](https://the-stall.intuitek.ai) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |
 | Dodo Payments | Payments | `https://mcp.dodopayments.com/sse` | API Key | [Dodo Payments](https://dodopayments.com) |
 | Polar Signals | Software Development | `https://api.polarsignals.com/api/mcp/` | API Key | [Polar Signals](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) |


### PR DESCRIPTION
**The Stall** is a remote MCP server with 28 AI-callable data tools — no API key required.

**URL:** `https://the-stall.intuitek.ai/mcp`
**Transport:** Streamable HTTP
**Auth:** Open (free MCP access; x402 USDC micropayments for per-call data at `/cap/<name>`)

**Categories of tools:**
- Market data: US stocks, equity technicals, macro indicators, commodity futures, forex rates
- Crypto/DeFi: funding rates, DeFi yields, stablecoin depeg monitor, DEX trending pools, gas prices
- Security: EVM token security, Solana token risk, wallet screener
- Intelligence: Hacker News, GitHub repos, npm/PyPI packages, Korean market movers
- Misc: prediction markets, meme generation, weather, on-chain tx explainer

**Add config:**
```json
{"mcpServers":{"the-stall":{"url":"https://the-stall.intuitek.ai/mcp","transport":"streamable-http"}}}
```

Also listed: MCP registry (`ai.intuitek.the-stall/the-stall`), Smithery (`thebrierfox/the-stall`). Built by IntuiTek¹.