### PR TITLE
Add SkinKnowledgeBase remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
+| SkinKnowledgeBase | Skincare / Product Research | `https://mcp.skinknowledgebase.com/mcp` | Open | [SkinKnowledgeBase](https://github.com/fulcrai/skb-mcp) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |


### PR DESCRIPTION
## Summary

Add SkinKnowledgeBase as a public remote MCP server.

- Endpoint: https://mcp.skinknowledgebase.com/mcp
- Public repo/docs: https://github.com/fulcrai/skb-mcp
- Auth: Open / unauthenticated

SkinKnowledgeBase provides source-backed skincare question answering and product comparison context for AI assistants.
