### PR TITLE
Add Pyrimid remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
+| Pyrimid | Payments | `https://pyrimid.ai/api/mcp` | Open / x402 | [Pyrimid](https://pyrimid.ai) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |


### PR DESCRIPTION
Adds Pyrimid to the remote MCP server list.

Why it fits:
- Official remote MCP endpoint: https://pyrimid.ai/api/mcp
- Discovery metadata: https://pyrimid.ai/.well-known/mcp.json
- The server provides an x402/Base USDC catalog for paid AI/API products, paid MCP tools, affiliate routing, and agent-commerce workflows.
- The project is actively maintained at https://github.com/pyrimid-ai/pyrimid