### PR TITLE
feat: add TWZRD Agent Intel – x402 micropayment Solana trust scoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| TWZRD Agent Intel | Agent Trust | `https://intel.twzrd.xyz/mcp` | x402 Micropayment | [TWZRD](https://intel.twzrd.xyz) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
## New Server: TWZRD Agent Intel

**Category**: Agent Trust
**URL**: `https://intel.twzrd.xyz/mcp` (streamable-http)
**Auth**: x402 micropayment (USDC on Solana, no API key or OAuth required)
**Maintainer**: [TWZRD](https://intel.twzrd.xyz)

### Description
Solana on-chain agent trust scoring via x402 micropayments. Agents call the free preflight endpoint first (ReadinessCard: can_spend / trust_score / decision), then optionally pay $0.05 USDC for full trust intelligence + a portable offline-verifiable V5 receipt.

### Tools (8 total)
- Free: `get_readiness_card`, `score_wallet_for_intel`, `get_top_intel_agents`, `verify_receipt`
- Paid ($0.05 USDC on Solana): `get_trust_score`, `get_wallet_reputation`
- Paid ($0.03 USDC on Solana): `get_market_intel`, `get_agent_signals`

### Discovery surfaces
- PyPI: `pip install twzrd-agent-intel` (stdio mode)
- Smithery: https://smithery.ai/servers/wzrd/twzrd-agent-intel
- OpenAPI: https://intel.twzrd.xyz/openapi.json

### Auth note
This server uses `x402` micropayment auth (permissionless USDC on Solana) — happy to use a different label.