### PR TITLE
feat: add TWZRD Agent Intel remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
+| TWZRD Agent Intel | Crypto | `https://intel.twzrd.xyz/mcp` | x402 (USDC/free) | [TWZRD](https://intel.twzrd.xyz) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |
 | Dodo Payments | Payments | `https://mcp.dodopayments.com/sse` | API Key | [Dodo Payments](https://dodopayments.com) |
+| TWZRD Agent Intel | Crypto | `https://intel.twzrd.xyz/mcp` | Open / x402 | [TWZRD](https://intel.twzrd.xyz) |
 | Polar Signals | Software Development | `https://api.polarsignals.com/api/mcp/` | API Key | [Polar Signals](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) |
 | Manifold | Forecasting | `https://api.manifold.markets/v0/mcp` | Open | [Manifold](https://manifold.markets) |
 | Javadocs | Software Development | `https://www.javadocs.dev/mcp` | Open | [Javadocs.dev](https://javadocs.dev) |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |
 | Dodo Payments | Payments | `https://mcp.dodopayments.com/sse` | API Key | [Dodo Payments](https://dodopayments.com) |
-| TWZRD Agent Intel | Crypto | `https://intel.twzrd.xyz/mcp` | Open / x402 | [TWZRD](https://intel.twzrd.xyz) |
 | Polar Signals | Software Development | `https://api.polarsignals.com/api/mcp/` | API Key | [Polar Signals](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) |
 | Manifold | Forecasting | `https://api.manifold.markets/v0/mcp` | Open | [Manifold](https://manifold.markets) |
 | Javadocs | Software Development | `https://www.javadocs.dev/mcp` | Open | [Javadocs.dev](https://javadocs.dev) |


### PR DESCRIPTION
Adds TWZRD Agent Intel to the remote MCP server list.

**TWZRD Agent Intel** is a production remote MCP server hosted at `https://intel.twzrd.xyz/mcp` (Streamable-HTTP).

| Field | Value |
|-------|-------|
| Category | Crypto |
| URL | `https://intel.twzrd.xyz/mcp` |
| Authentication | Open (4 free tools) / x402 (4 paid tools) |
| Maintainer | [TWZRD](https://intel.twzrd.xyz) |

**What it does**: Solana-native agent trust scoring — 4 free preflight tools score any Solana wallet for trustworthiness; 4 paid tools deliver signed `twzrd.receipt.v5` trust tokens via x402 micropayments (USDC on Solana, <1s settlement).

Meets quality criteria:
- Maintained by TWZRD (the underlying team)
- Production-ready (live server, stable uptime)
- Listed on official MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`