### PR TITLE
Add Archyl remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
+| Archyl | Software Architecture | `https://api.archyl.com/mcp` | OAuth2.1 | [Archyl](https://www.archyl.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adds **Archyl** to the Remote MCP Server List.

Archyl is an AI-powered architecture documentation platform built on the C4 model. It ships an official, production remote MCP server so AI agents can query the architecture model, read ADRs and conformance rules, and create/update C4 elements through natural conversation.

| Field | Value |
|-------|-------|
| Name | Archyl |
| Category | Software Architecture |
| URL | `https://api.archyl.com/mcp` |
| Authentication | OAuth 2.1 (dynamic client registration) |
| Maintainer | [Archyl](https://www.archyl.com) |

Against the quality criteria:
- **Official support**: maintained by Archyl (the vendor).
- **Production ready**: live at `https://api.archyl.com/mcp`.
- **Security**: OAuth 2.1 — `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` both return 200; protected resource advertises `mcp:read` / `mcp:write` scopes. Unauthenticated `POST /mcp` returns 401 as expected.

Inserted alphabetically between Airtable and Asana. Disclosure: I'm involved with Archyl.