### PR TITLE
Add Unstoppable Domains MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
+| Unstoppable Domains | Domains | `https://api.unstoppabledomains.com/mcp/v1/` | OAuth2.1 | [Unstoppable Domains](https://unstoppabledomains.com) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |
 | VibeMarketing | Social Media | `https://vibemarketing.ninja/mcp` | OAuth2.1 | [VibeMarketing](https://vibemarketing.ninja) |


### PR DESCRIPTION
Adds the official Unstoppable Domains MCP server — a domain registrar / DNS management remote MCP.

- **Server name:** Unstoppable Domains
- **Category:** Domains (new — no existing domain-registrar category on the list; happy to merge into an existing category if preferred)
- **URL:** `https://api.unstoppabledomains.com/mcp/v1/`
- **Authentication:** OAuth 2.1 with dynamic client registration (`registration_endpoint` advertised in `/.well-known/oauth-authorization-server`), or `ud_mcp_*` API key as an alternative
- **Maintainer:** Unstoppable Domains (vendor-maintained)
- **Registry:** [`com.unstoppabledomains/mcp-server`](https://registry.modelcontextprotocol.io/v0/servers?search=unstoppabledomains) (Official MCP Registry, DNS-verified namespace)
- **Tools:** 60 (domain search, DNS management, marketplace listings, cart/checkout, AI landing pages, portfolio operations)
- **Repo:** https://github.com/unstoppabledomains/unstoppable-mcp-server

**Example usage:** "Register example.com for two years and set up Google Workspace MX records."

Inserted alphabetically between `TweetSave` and `xbird` in the table.