### PR TITLE
Add MindDory (language-learning vocabulary connector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
+| MindDory | Language Learning | `https://api.minddory.com/v1/brain/mcp` | OAuth2.1 | [MindDory](https://minddory.com) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 


### PR DESCRIPTION
Adds **MindDory**, a remote MCP server (OAuth 2.1, streamable-http) for vocabulary / language learning.

It lets an MCP client act as a language study partner: capture new words from conversation into spaced-repetition flashcards, log grammar mistakes, read the user's review queue and known words, and reinforce words via SM-2 updates. Transparent and opt-in.

- Endpoint: `https://api.minddory.com/v1/brain/mcp`
- Auth: OAuth 2.1 (returns 401 to unauthenticated requests for OAuth discovery)
- Published to the official MCP registry as `com.minddory/brain`
- Hosted in the EU
- Website: https://minddory.com · Setup: https://minddory.com/connect · Repo: https://github.com/Hyneq00/minddory-mcp

Live in production (iOS, Android, web) with the connector verified working in Claude. Row added alphabetically; OAuth2.1 per the list's auth criteria.