### PR TITLE
Add Oktopus (cash-on-delivery payments rail for LATAM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
+| Oktopus | Payments | `https://www.oktopus.lat/mcp` | API Key | [Oktopus](https://www.oktopus.lat) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
Adds **Oktopus** to the Remote MCP Server List under **Payments** (alphabetical, between Octagon and OneContext).

Oktopus is a remote (Streamable HTTP) MCP server: the **cash-on-delivery (COD) checkout rail for LATAM**. An agent can run a dropshipping store end to end — create products and AI landing pages, connect Dropi, and **create & collect cash-on-delivery orders** (the dominant payment method in LATAM e-commerce, which card/wallet rails like PayPal/Plaid don't cover).

| Field | Value |
|---|---|
| URL | `https://www.oktopus.lat/mcp` |
| Auth | API Key (OAuth 2.1 + PKCE rolling out) |
| Category | Payments |
| Maintainer | Oktopus (oktopus.lat) |

- Production: live, in the official MCP registry as `lat.oktopus/checkout-cod`.
- Guide for agents: https://www.oktopus.lat/para-agentes

Meets the quality criteria: official/company-maintained, production-ready, API-Key auth (OAuth 2.1 shipping).