### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
 
 
+| The Stall | Market Intelligence | `https://the-stall.intuitek.ai/mcp` | x402 (USDC micropayments) | [IntuiTek¹](https://intuitek.ai) |
+
 # Remote MCP Installation Guide
 
 > Kindy powered by [Install This MCP](https://github.com/janwilmake/install-this-mcp)


### PR DESCRIPTION
## Add The Stall MCP Server

The Stall is a production remote MCP server offering 210 pay-per-call AI capabilities via x402 USDC micropayments on Base. It is the first MCP service to implement x402-native pay-per-call billing at scale.

**What agents get:**
- 210 capabilities: stocks (US/EU/JP/KR), crypto/DeFi, options GEX, insider trades, macro, congressional trades, weather, Solana meme coins, Twitter/X intelligence, vision analysis, and more
- Pay-per-call via USDC on Base (EIP-712 x402 protocol)
- No API keys, no subscriptions — agents pay only for what they use
- Free `/mcp` endpoint for capability discovery

**New in v4.64.0:**
- `meme-radar` — Solana meme coin quality-volume ranking (DexScreener free API)
- `twitter-intel` — real-time Twitter/X data via x402-to-x402 relay
- `market-gex` — dealer gamma exposure (GEX) via CBOE free data

**Connect:**
```json
{"mcpServers": {"the-stall": {"type": "streamable-http", "url": "https://the-stall.intuitek.ai/mcp"}}}
```

git: b01da80 | version: v4.64.0 | live: https://the-stall.intuitek.ai
