### PR TITLE
Add SocialGPT (Social Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
+| SocialGPT | Social Media | `https://mcp.gpt.social/mcp` | OAuth2.1 | [SocialGPT](https://gpt.social) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |


### PR DESCRIPTION
Adds **SocialGPT** to the list (alphabetical, after Stack Overflow).

- **Name**: SocialGPT
- **Category**: Social Media
- **URL**: `https://mcp.gpt.social/mcp` (streamable HTTP)
- **Authentication**: OAuth 2.1 + PKCE (MCP spec resource-server flow, dynamic client registration supported)
- **Maintainer**: [Scrollmark](https://gpt.social) — official first-party server
- **Example usage**: connect, then ask your agent *"How did my content perform this month vs last?"* or *"What's working for fitness creators on TikTok?"* — tools cover your own analytics, deep video analysis (hooks, themes, transcripts), and public/competitor creator intel across TikTok, Instagram, and YouTube. Public-creator analysis works before connecting any social account.

Also published in the official MCP registry as `io.github.scrollmark/socialgpt`; public repo with per-client setup at https://github.com/scrollmark/socialgpt-mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)