### PR TITLE
Add Hlido (AI Evaluation) to remote MCP server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
+| Hlido | AI Evaluation | `https://hlido.eu/mcp` | Open | [Hlido](https://hlido.eu) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |


### PR DESCRIPTION
Adds Hlido under AI Evaluation. Hlido is an independent review desk for AI agents; the hosted remote MCP server at `https://hlido.eu/mcp` exposes trust checks, ranked recommendations, head-to-head comparisons, and signed scorecards. Open auth — the free tier needs no key, so it's copy-paste usable in any MCP-ready client. Verified live (`tools/list` responds) before submitting.

Disclosure: submitted by Hlido's founder (PR prepared by an automated agent).
