### PR TITLE
Add Adeu MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| Adeu | Productivity | `https://app.adeu.ai/api/v1/mcp` | OAuth2.1 🔐 & API Key | [Adeu](https://adeu.ai) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
Adding Adeu to the list.

**What it does:** Adeu is an AI email assistant. The MCP server exposes tools for searching, reading, and drafting emails across linked Microsoft and Google mailboxes (including shared and delegated mailboxes), plus reading and applying tracked-changes edits to local DOCX files via a local daemon.

**Authentication:**
- OAuth 2.1 (no dynamic client registration), used by Gemini Enterprise via Google as the identity provider
- Adeu-issued Personal Access Token (API Key), used by Claude Desktop, Cursor, and other MCP clients

Dual auth precedent in the existing list: Stripe (OAuth2.1 & API Key).

**Production status:** Live and actively maintained. Endpoint: https://app.adeu.ai/api/v1/mcp

**Signup:** Adeu accounts are currently invite-gated. Trial access is available by contacting pekka@adeu.ai. Several entries on the existing list (Cortex, HubSpot, etc.) are similarly gated.

Happy to answer any questions during review.