### PR TITLE
Add NumerTel - Polish phone number reputation (remote streamable HTTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
+| NumerTel | Threat Intelligence | `https://numertel.pl/api/mcp` | Open / API Key | [NumerTel](https://numertel.pl) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |


### PR DESCRIPTION
Adds **NumerTel**, an owner-operated production MCP server for Polish phone-number reputation (130M numbers). Remote streamable HTTP at `https://numertel.pl/api/mcp`, rate limit 30/day/IP plus API keys. Docs: https://numertel.pl/dla-deweloperow . Listed in the official MCP registry as `pl.numertel/numertel`. Category Threat Intelligence (same as Malware Patrol). Inserted alphabetically under N.