### PR TITLE
Add NIPRegon - Polish company registry (remote streamable HTTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
+| NIPRegon | Business Data | `https://api.nipregon.pl/mcp` | Open / API Key | [NIPRegon](https://nipregon.pl) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |


### PR DESCRIPTION
Adds **NIPRegon**, an owner-operated production MCP server for the Polish company registry (4.4M companies). Remote streamable HTTP at `https://api.nipregon.pl/mcp`, rate limit 100/day/IP plus API keys. Tools: company search, full registry data by NIP (KRS/REGON/PKD/board/VAT), financial statements, and VAT white-list checks before payments. Docs: https://nipregon.pl/mcp . Official MCP registry: `pl.nipregon/nipregon`. Category Business Data, inserted alphabetically under N.