### PR TITLE
Add OpenChainBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
+| OpenChainBench | Crypto | `https://openchainbench.com/api/mcp/mcp` | Open | [OpenChainBench](https://openchainbench.com) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Parallel Search MCP | Web Search | `https://search-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
Adds OpenChainBench, a remote MCP server for live crypto infrastructure benchmarks (RPC latency, bridge fees and times, aggregator quote freshness, perps funding). Streamable HTTP, no auth, read only. Tools: list_benchmarks, get_benchmark, query_prom, plus 20 benchmarks exposed as MCP resources. Server URL: https://openchainbench.com/api/mcp/mcp, docs at https://openchainbench.com/mcp. Source: https://github.com/ChainBench/OpenChainBench (MIT), data CC-BY-4.0, refreshes every 60s.