### PR TITLE
Add gethumandesign (Human Design) remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| gethumandesign (Human Design) | Wellness | `https://api.gethumandesign.com/mcp` | OAuth2.1 | [gethumandesign](https://www.gethumandesign.com) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
## What

Adds **gethumandesign (Human Design)** to the remote MCP server list:

- **URL**: `https://api.gethumandesign.com/mcp` (Streamable HTTP)
- **Authentication**: OAuth 2.0 per the MCP spec — connect with just the server URL, the client guides you through the auth flow
- **Maintainer**: [gethumandesign](https://www.gethumandesign.com) — docs at https://www.gethumandesign.com/mcp-docs/

Calculate Human Design bodygraph charts from birth data, save people, compare charts, and analyse group dynamics in any MCP client.

## Quality criteria

- **Official**: first-party server, built and maintained by gethumandesign.com; also listed in the [official MCP registry](https://registry.modelcontextprotocol.io) as `com.gethumandesign.www/mcp`
- **Production ready**: live production service powering the gethumandesign.com app; works with Claude (custom connectors), ChatGPT, and other MCP clients
- **Security**: OAuth 2.0 following the MCP spec, with proper audience binding
- **Maintained**: actively developed, with documentation and support via the website

🤖 Generated with [Claude Code](https://claude.com/claude-code)