### PR TITLE
Add Xquik remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |
+| Xquik | Social Media | `https://xquik.com/mcp` | API Key | [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) |
 | Vercel | Software Development | `https://mcp.vercel.com/` | OAuth2.1 | [Vercel](https://vercel.com) |
 | VibeMarketing | Social Media | `https://vibemarketing.ninja/mcp` | OAuth2.1 | [VibeMarketing](https://vibemarketing.ninja) |
 | Webflow | CMS | `https://mcp.webflow.com/sse` | OAuth2.1 | [Webflow](https://webflow.com) |


### PR DESCRIPTION
## Summary
- Add Xquik to the remote MCP server table under Social Media.
- Link the public remote MCP endpoint and source repository.

## Fit
- Xquik is a first-party remote MCP endpoint with API-key authentication.
- The public package has recent releases and MIT licensing.
- The endpoint is documented at https://docs.xquik.com/mcp/overview.

## Validation
- Git diff check passed.
- Added-line confidentiality scan passed.
- Repository link returned 200.
- MCP docs link returned 200.
- MCP endpoint returned 401 without an API key, as expected.
- Target branch, PR, and issue duplicate searches found no Xquik entry.
