### PR TITLE
Add Mission — Trust Graduation gate for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
-| Mission | Productivity | `https://claude.gomission.io/mcp/` | OAuth2.1 | [Mission](https://claude.gomission.io) |
+| Mission [![gomission/mcp MCP server](https://glama.ai/mcp/servers/gomission/mcp/badges/score.svg)](https://glama.ai/mcp/servers/gomission/mcp) | Productivity | `https://claude.gomission.io/mcp/` | OAuth2.1 | [Mission](https://claude.gomission.io) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
+| Mission | Productivity | `https://claude.gomission.io/mcp/` | OAuth2.1 | [Mission](https://claude.gomission.io) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |


### PR DESCRIPTION
## What this server is

**Mission** is a remote MCP server that adds a **Trust Graduation** gate to any MCP client. When an AI agent (Claude, ChatGPT, or any MCP-compatible runtime) attempts a consequential action — send email, post publicly, schedule a meeting, spend money — Mission holds the action with a visible approval ceremony and a receipt id, and never proceeds without explicit principal approval.

The hosted endpoint at `https://claude.gomission.io/mcp/` cannot send, post, schedule, or spend by protocol. The four Trust Graduation primitives (`mission_status`, `request_approval`, `log_action`, `get_receipt`) make the permission boundary visible inline in the chat.

## Why it meets the quality criteria

- **Official Support**: Maintained by Phenomena Labs Ltd. (https://gomission.io). Single official endpoint.
- **Production Ready**: Live and verified. 16 tools exposed. OAuth metadata at `/.well-known/oauth-authorization-server`.
- **Active Maintenance**: Published today as part of the Mission for Claude launch.
- **Security**: OAuth 2.1 with five read scopes (`read_today`, `read_drafts`, `read_receipts`, `read_voice_profile`, `read_research`). Read-only by protocol — no external action is possible without approval at the principal's workspace.
- **Reliability**: Hosted on DreamHost with Let's Encrypt SSL.
- **Community**: Open spec (Trust Graduation v0.1), zero-dependency reference wrapper at `@gomission/trust-graduation`.

## How it's used in production

- `npx -y @gomission/mcp install-claude` installs Mission to Claude Desktop via the `mcp-remote` stdio↔HTTP+SSE bridge.
- Listed in the official MCP Registry as `io.github.gomission/mcp` (https://registry.modelcontextprotocol.io/v0.1/servers/io.github.gomission/mcp/versions/latest).
- npm package: https://www.npmjs.com/package/@gomission/mcp
- Docs + 60-second demo: https://claude.gomission.io
- Full API reference: https://claude.gomission.io/docs.html

## Notable

The wedge sentence is *"Claude can do more for you once Mission decides what it's allowed to do."* The principle that distinguishes Trust Graduation from generic "human in the loop": permission is tracked **per action class** through Beta(2,2) Bayesian evidence, and external-effect classes (e.g., `email.send.external`, `social.post.public`, `payment.initiate`) never auto-promote past `gated` — they always require explicit principal approval, regardless of evidence.

Happy to answer questions about category fit or anything else. Thanks for maintaining this list.