### PR TITLE
Add D50 AI (sales/marketing/hiring MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
+| D50 AI | Sales & Marketing | `https://app.d50.ai/api/mcp` | OAuth2.1 / API Key | [D50 AI](https://d50.ai) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |


### PR DESCRIPTION
Adds **D50 AI** to the Remote MCP Server List.

- **Server:** `https://app.d50.ai/api/mcp` (streamable-HTTP)
- **Auth:** OAuth 2.1 + Bearer API key
- **What it does:** 246 tools to run sales, marketing & hiring end-to-end — CRM, a 4.6M-lead database, AI calling, ad generation & campaign management, content/video generation, recruiting & candidate screening, and SEO.
- **Docs:** https://d50.ai/developers/mcp
- Published in the official MCP registry as `ai.d50/d50-platform`.

Meets the quality criteria: production server, OAuth 2.1 + API-key auth, live remote endpoint.