### PR TITLE
Add dochost MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
+| dochost | Document Management | `https://dochost.io/api/mcp` | OAuth2.1 | [dochost](https://dochost.io/mcp) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |


### PR DESCRIPTION
dochost is a hosted remote MCP server that lets an AI assistant publish Markdown or HTML to a clean, public, shareable link — no copy-paste. It connects over Streamable HTTP and is OAuth-protected (no API keys).

- Endpoint: https://dochost.io/api/mcp
- Homepage: https://dochost.io/mcp
- Connect: `claude mcp add --transport http dochost https://dochost.io/api/mcp`