### PR TITLE
Add PostEverywhere under Social Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | CustomGPT.ai | RAG-as-a-service | `https://mcp.customgpt.ai` | API | [CustomGPT.ai](https://customgpt.ai) |
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
+| PostEverywhere | Social Media | `https://mcp.posteverywhere.ai/mcp` | OAuth2.1 | [PostEverywhere](https://posteverywhere.ai) |
 
 
 # Remote MCP Installation Guide


### PR DESCRIPTION
Adds **PostEverywhere**, a remote MCP server for scheduling and publishing social posts to Instagram, TikTok, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Bluesky, Discord and Telegram.

- URL: `https://mcp.posteverywhere.ai/mcp`
- Authentication: OAuth 2.1 (with dynamic client registration)
- Category: Social Media

Hosted, connect with one URL. Also available as the `@posteverywhere/mcp` npm package.
