### PR TITLE
feat(aggregators): add Prismix — AI monitoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
+| Prismix | AI Monitoring | `https://prismix.dev/api/v1/mcp` | Open | [Prismix](https://prismix.dev) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |


### PR DESCRIPTION
## Summary

Adds **Prismix** to the repository.

Prismix is a cloud-hosted MCP server that exposes real-time status information for 75+ AI services (OpenAI, Anthropic, Cursor, Mistral, Perplexity, and more).

Features:
- Real-time operational status for 75+ AI APIs and tools
- Incident history and 30-day uptime tracking
- Embeddable SVG status badges
- No auth required for status reads

MCP server: `https://prismix.dev/mcp` (remote, hosted)
Live: https://prismix.dev

Happy to adjust the format if anything doesn't match repo conventions.