### PR TITLE
Add htmlbook (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
+| htmlbook | Document Management | `https://htmlbook.io/api/mcp` | OAuth2.1 | [htmlbook](https://htmlbook.io) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |


### PR DESCRIPTION
Adds **htmlbook** to the remote MCP server list.

htmlbook is a hosted MCP server that lets an AI agent publish the HTML/Markdown it generates to a shareable, themed URL — it stores, organizes, versions, and publicly shares the doc.

| Field | Value |
|---|---|
| Endpoint | `https://htmlbook.io/api/mcp` (Streamable HTTP) |
| Auth | OAuth 2.1 with dynamic client registration (also supports static API keys) |
| Category | Document Management |
| Site | https://htmlbook.io |

Added in alphabetical order (between `Hive Intelligence` and `Instant`). Follows the table format in CONTRIBUTING.