### PR TITLE
Add Ignav Flights

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |
+| Ignav Flights | Airlines | `https://ignav.com/mcp` | Open / API Key | [Ignav](https://ignav.com) |
 | Invidio | Video Platform | `https://mcp.invideo.io/sse` | OAuth2.1 | [Invidio](https://invideo.io/) |
 | Jam | Software Development | `https://mcp.jam.dev/mcp` | OAuth2.1 | [Jam.dev](https://jam.dev/) |
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |


### PR DESCRIPTION
Adding Ignav Flights, the official remote MCP server for Ignav.

- Endpoint: https://ignav.com/mcp
- Docs: https://ignav.com/docs/mcp
- Repo/examples: https://github.com/gusgordon/ignav-skill
- Description: Provides live flight prices, booking links, and airport lookup for AI agents and travel apps.
- Auth: Anonymous for testing, optional `X-Api-Key` header for higher usage.

Let me know if you need anything else!
