### PR TITLE
Add Sequenzy remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
+| Sequenzy | Marketing | `https://api.sequenzy.com/v1/mcp` | OAuth2.1 / API Key | [Sequenzy](https://sequenzy.com) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |


### PR DESCRIPTION
Adds Sequenzy's official hosted remote MCP endpoint.\n\n- Endpoint: https://api.sequenzy.com/v1/mcp\n- Maintainer: Sequenzy\n- Repository: https://github.com/Sequenzy/mcp