### PR TITLE
Add WoopSocial MCP - unified social media API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Webflow | CMS | `https://mcp.webflow.com/sse` | OAuth2.1 | [Webflow](https://webflow.com) |
 | Wix | CMS | `https://mcp.wix.com/sse` | OAuth2.1 | [Wix](https://wix.com) |
 | WebZum | Website Hosting | `https://webzum.com/api/mcp` | Open | [WebZum](https://webzum.com) |
+| WoopSocial | Social Media | `https://api.woopsocial.com/mcp` | OAuth2.1 & API Key | [WoopSocial](https://woopsocial.com/social-media-mcp) |
 | Simplescraper | Web Scraping | `https://mcp.simplescraper.io/mcp` | OAuth2.1 | [Simplescraper](https://simplescraper.io) |
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
 | Zenable | Security | `https://mcp.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |


### PR DESCRIPTION
Adds WoopSocial's official remote MCP server. This allows access to the underlying unified social media API to schedule posts across various social media platforms including Facebook, Instagram, LinkedIn, Pinterest, TikTok, X and YouTube.

### Details
- **Authentication**: Both OAuth 2.1 and API key based authentication is supported. 
- **Official MCP Registry**: Listed as `com.woopsocial/mcp`
- **Documentation**: https://docs.woopsocial.com/mcp/overview