### PR TITLE
Add TLS Radar (SSL/TLS scanning + free Let's Encrypt issuance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
+| TLS Radar | Security | `https://tlsradar.com/api/v1/mcp` | Open / OAuth2.1 | [TLS Radar](https://tlsradar.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |


### PR DESCRIPTION
Adds **TLS Radar**, a remote MCP server for SSL/TLS work.

| Field | Value |
|---|---|
| URL | \`https://tlsradar.com/api/v1/mcp\` (Streamable HTTP) |
| Auth | Open for the public scan/cert tools; OAuth 2.1 for monitoring |
| Category | Security |

What it does: free SSL/TLS scanning, free Let's Encrypt certificate issuance (private key stays on the client), and certificate-expiry monitoring. Public `scan`/`cert_*` tools need no account, so it's trivially testable: an unauthenticated `tools/list` returns 17 tools.

**Quality criteria:** officially maintained by TLS Radar, production (live, hosted), OAuth 2.1 for the authenticated tools. Also listed in the official MCP Registry (\`com.tlsradar/tlsradar\`) and on Smithery (81/100).