### PR TITLE
Add ShotAPI - remote screenshot & render MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
+| ShotAPI | Browser Automation | `https://aiphotoshop.mynatapp.cc/mcp` | Open / API Key | [ljs](https://github.com/smallhandsome) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |


### PR DESCRIPTION
ShotAPI MCP Server - Web screenshot and HTML render for AI agents.

- URL: https://aiphotoshop.mynatapp.cc/mcp
- Transport: streamable-http (remote, zero install)
- Auth: Open / API Key
- Category: Browser Automation
- Free: 100+100/month

One command: `claude mcp add --transport streamable-http shotapi https://aiphotoshop.mynatapp.cc/mcp`