### PR TITLE
Add Keenable (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |
 | Invidio | Video Platform | `https://mcp.invideo.io/sse` | OAuth2.1 | [Invidio](https://invideo.io/) |
 | Jam | Software Development | `https://mcp.jam.dev/mcp` | OAuth2.1 | [Jam.dev](https://jam.dev/) |
+| Keenable | Web Search | `https://api.keenable.ai/mcp` | Open / API Key | [Keenable](https://keenable.ai) |
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |


### PR DESCRIPTION
## Add Keenable (remote MCP server)

Adds [Keenable](https://keenable.ai) — a web search and page-fetch service — to the Remote MCP Server List.

| Field | Value |
|---|---|
| **Name** | Keenable |
| **Category** | Web Search |
| **URL** | `https://api.keenable.ai/mcp` (Streamable HTTP) |
| **Authentication** | Open / API Key |
| **Maintainer** | [Keenable](https://keenable.ai) |
| **Docs** | https://docs.keenable.ai/mcp-server |

### What it does

Exposes two tools over MCP:

- `search_web_pages` — web search returning ranked results (URL, title, description), with site and date filters (published/acquired, absolute or relative).
- `fetch_page_content` — fetches an indexed URL and returns clean markdown.

### Authentication

Listed as **Open / API Key**. The server works with no account at all; passing an optional `X-API-Key` header just removes the hourly cap. OAuth 2.1 is also supported but the docs currently recommend API keys over it.

| Auth status | Rate limit |
|---|---|
| Unauthenticated | 1,000 req/hour, max 10 req/s (per IP) |
| Authenticated (API key) | 10 req/s (per organization), no hourly cap |

API usage is currently free. ([rate limits](https://docs.keenable.ai/rate-limits))

### Placement

Inserted alphabetically in the **K** group, between **Jam** and **Kollektiv**, matching the list's existing ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)