### PR TITLE
Add OnePageCRM remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
+| OnePageCRM | CRM | `https://app.onepagecrm.com/mcp` | OAuth2.1 | [OnePageCRM](https://www.onepagecrm.com) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |
 | Parallel Search MCP | Web Search | `https://search-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
Adds OnePageCRM's official remote MCP server.

| Name | Category | URL | Authentication | Maintainer |
|------|----------|-----|----------------|------------|
| OnePageCRM | CRM | `https://app.onepagecrm.com/mcp` | OAuth2.1 | [OnePageCRM](https://www.onepagecrm.com) |

**Quality criteria:**

- **Official Support:** published and operated by OnePageCRM; listed in the official [MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=com.onepagecrm) as `com.onepagecrm/mcp` with verified `onepagecrm.com` domain ownership.
- **Production Ready:** publicly available at `app.onepagecrm.com/mcp`, in daily use by customers via Claude, ChatGPT, and other MCP clients; ~0% error rate and sub-second latency.
- **Authentication:** OAuth 2.1 with RFC 7591 dynamic client registration + PKCE.
- **Tools:** 5: `describe`, `context`, `query`, `create`, `update` - covering contacts, deals, the action stream, notes, calls, and meetings via the OnePageCRM Query Language (OQL).

**Placement:** alphabetically after OneContext (before PayPal).
**Category:** `CRM` - follows the precedent set by Attio, Close, and HubSpot.
