### PR TITLE
Add Daemoon — open-source MCP gateway for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
+| Daemoon | Software Development | `https://daemoon.dev/api/mcp` | OAuth2.1 / Bearer | [Daemoon](https://daemoon.dev) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |


### PR DESCRIPTION
Adding **Daemoon**, an open-source remote MCP gateway. One bearer token gives any MCP-aware AI coding agent (Claude Code, Cursor, Cline, Continue, Zed, etc.) unified, encrypted access to nine providers: Vercel, GitHub, Cloudflare, Supabase, GCP, Stripe, Resend, OpenAI, Anthropic.

## Why include

- **Remote-only**: served at `https://daemoon.dev/api/mcp` — no install, just a bearer.
- **MCP spec compliant**: JSON-RPC 2.0, MCP Streamable HTTP protocol `2025-06-18`. Implements `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `ping`.
- **OAuth 2.0**: Protected Resource Metadata (RFC 9728), Authorization Server Metadata (RFC 8414), Dynamic Client Registration (RFC 7591), PKCE-S256. Also accepts static `Authorization: Bearer dmn_...` for clients that don't speak OAuth.
- **Security**: AES-256-GCM envelope encryption of every stored provider token; per-token DEK wrapped by master key. Per-provider revoke + per-agent PAT revoke from the dashboard.
- **Open source**: MIT, self-hostable. https://github.com/daemoon-dev/daemoon
- **MCP Registry**: registered as `io.github.jaylee7777/daemoon`.
- **Maintainer**: Daemoon (jaylee7777 / daemoon-dev org).

## Discovery endpoints

- Server card: `https://daemoon.dev/.well-known/mcp.json`
- llms.txt: `https://daemoon.dev/llms.txt`
- PRM: `https://daemoon.dev/.well-known/oauth-protected-resource`
- AS metadata: `https://daemoon.dev/.well-known/oauth-authorization-server`

Inserted alphabetically between `Cortex` and `Dialer` under category `Software Development`. Authentication is listed as `OAuth2.1 / Bearer` since both are supported.