### PR TITLE
Add UptimeMonitoring (remote uptime monitoring MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
 | Wolfram | Productivity | `https://agenttools.wolfram.com/mcp` | Open | [Wolfram Research](https://www.wolfram.com/) |
+| UptimeMonitoring | Observability | `https://api.uptimemonitoring.com/mcp` | OAuth2.1 | [UptimeMonitoring](https://uptimemonitoring.com) |
 
 # Remote MCP Installation Guide
 


### PR DESCRIPTION
Adding **UptimeMonitoring** — an agent-native uptime monitoring service with a remote MCP server.

| Field | Value |
|---|---|
| Name | UptimeMonitoring |
| Category | Observability |
| URL | `https://api.uptimemonitoring.com/mcp` |
| Auth | OAuth 2.1 (with dynamic client registration) or Bearer API key |
| Maintainer | https://uptimemonitoring.com |

Meets the quality criteria:
- **Official** — built and maintained by the UptimeMonitoring team (MONITIVE COM SRL).
- **Production ready** — live in the [official MCP Registry](https://registry.modelcontextprotocol.io) as `com.uptimemonitoring/mcp`.
- **Security** — OAuth 2.1 (PKCE, dynamic client registration) and API-key auth.
- **Remote** — Streamable HTTP transport.

Tools: list/get/create/update/delete monitors, list incidents, assert monitor healthy, get account status. Free 50-monitor tier.