### PR TITLE
Add Bible Glide remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
+| Bible Glide | Learning | `https://api.bibleglide.com/mcp` | OAuth2.1 | [Bible Glide](https://www.bibleglide.com/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |


### PR DESCRIPTION
Adds Bible Glide to the remote MCP server list.

Why it fits this list:
- Official remote MCP endpoint from Bible Glide: https://api.bibleglide.com/mcp
- OAuth-authenticated account context and Bible study tools
- Public MCP documentation page: https://www.bibleglide.com/mcp
- Already published in the official MCP Registry and Smithery