### PR TITLE
Add BuyWhere MCP server to Product Data category

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
+| BuyWhere | Product Data | `https://api.buywhere.ai/mcp` | API Key | [BuyWhere](https://buywhere.ai) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |


### PR DESCRIPTION
## What

Adds BuyWhere MCP server to the Product Data category. BuyWhere is a cross-border e-commerce product search and price comparison API for AI agents, exposing **11M+ products across 3,700+ retailers** in Singapore, Southeast Asia, and US markets.

## Why Product Data

Same category as EAN-Search.org — product data APIs for AI agents. BuyWhere returns structured product results (price, merchant, inventory, brand, category) optimized for agent commerce.

## Auth

API Key (no OAuth). Free self-service key in 3 seconds — `POST https://api.buywhere.ai/v1/auth/register {"agent_name": "<name>"}` returns a Bearer token, no signup, no email.

Note: CONTRIBUTING.md says OAuth 2.0 is *preferred*, not required. Existing entries with API Key include Malware Patrol and xbird. If auth preference is a hard requirement, happy to discuss an OAuth wrapper or convert the entry to a different category.

## Production criteria check

- ✅ Official support — BuyWhere/buywhere-mcp maintained by BuyWhere
- ✅ Production ready — 11M+ products live on https://buywhere.ai
- ✅ Active maintenance — 1.0.4 release, regular updates, public roadmap
- ✅ Security — API Key auth, rate limited, no agent-side state
- ✅ Reliability — 99.9% uptime target
- ✅ Community — npm `@buywhere/mcp-server`, listed on Glama, Smithery, MCP Registry

## Endpoint

`https://api.buywhere.ai/mcp` (streamable-http)

## Tools

- `search_products(query, market, currency, ...)` — full-text product search across 11M+ products
- `find_similar(product_id, limit)` — similar-product discovery
- `get_product(product_id)` — full product detail with price history
- `find_deals(market, category, max_price)` — deal discovery
- `get_catalog()` — category taxonomy for the active market

## Links

- Source: https://github.com/BuyWhere/buywhere-mcp
- Docs: https://buywhere.ai/api-keys
- Glama: https://glama.ai/mcp/servers/BuyWhere/buywhere-mcp
- MCP Registry: https://registry.modelcontextprotocol.io/v0/servers?search=buywhere

Co-Authored-By: Paperclip <noreply@paperclip.ing>