### PR TITLE
Add datavessel (marketing & ecommerce, OAuth 2.1 DCR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
+| datavessel | Marketing & Ecommerce | `https://mcp.datavessel.io/mcp` | OAuth2.1 | [datavessel](https://datavessel.io) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |


### PR DESCRIPTION
Adds **datavessel** to the remote servers table (alphabetical, in the OAuth2.1 tier).

- **URL:** `https://mcp.datavessel.io/mcp` (Streamable HTTP)
- **Auth:** OAuth 2.1 with dynamic client registration — connect with just the URL, no pre-registration or API key.
- **What it does:** read **and write** access to a full marketing & ecommerce stack — Google Analytics, Search Console, Google & Meta Ads, Shopify, WooCommerce, Shopware, Slack, LinkedIn (100+ tools across 10 connectors).

Published on the official MCP Registry as `io.github.djr4/datavessel`.