### PR TITLE
Add PodPast (remote MCP, OAuth) - RAG over podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
 | Wolfram | Productivity | `https://agenttools.wolfram.com/mcp` | Open | [Wolfram Research](https://www.wolfram.com/) |
+| PodPast | RAG-as-a-Service | `https://podpast.ai` | OAuth2.1 | [PodPast](https://podpast.ai) |
 
 # Remote MCP Installation Guide
 


### PR DESCRIPTION
Adds **PodPast** - a hosted Claude connector (remote MCP, OAuth) that turns the podcasts and YouTube shows you follow into a searchable knowledge source: ask what a guest said and get the exact quote with a timestamp.

Homepage: https://podpast.ai
Docs: https://github.com/tomdoeswork/podpast-connector-docs
