### PR TITLE
Add Allowance MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
+| Allowance | Payments | `https://mcp.useallowance.com` | API Key | [Allowance](https://github.com/useallowance/allowance-mcp-public) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
-| Allowance | Payments | `https://mcp.useallowance.com` | API Key | [Allowance](https://github.com/useallowance/allowance-mcp-public) |
+| Allowance | Payments | `https://mcp.useallowance.com` | OAuth2.1 | [Allowance](https://github.com/useallowance/allowance-mcp-public) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adds Allowance MCP to the remote MCP server list.\n\n- Hosted server: https://mcp.useallowance.com\n- Public metadata repo: https://github.com/useallowance/allowance-mcp-public\n- Official registry: https://registry.modelcontextprotocol.io/v0.1/servers/com.useallowance%2Fallowance-mcp/versions/latest\n\nAllowance is a payment security layer for AI agents: agents request scoped human approval and use limited virtual cards instead of seeing the human's real card.