### PR TITLE
Add ClarityBriefs — free cross-lingual news briefings MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
+| ClarityBriefs | News | `https://claritybriefs.com/api/mcp` | Open | [ClarityBriefs](https://claritybriefs.com) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |


### PR DESCRIPTION
Adds **ClarityBriefs**, a free, read-only remote MCP server for AI agents.

- **Endpoint:** `https://claritybriefs.com/api/mcp` (Streamable HTTP, JSON-RPC 2.0, spec 2025-11-25)
- **Auth:** Open (no auth for public tools)
- **Category:** News
- **What it does:** Token-efficient compact news briefings across 89 languages. `get_compact_brief` is **cross-lingual** — one call searches foreign-language news pools (e.g. Korean/Japanese) tagged by source language.
- Also listed in the official MCP Registry: `com.claritybriefs/mcp`
- Docs: https://claritybriefs.com/agents

Inserted alphabetically in the Remote MCP Server List table.