### PR TITLE
Add Syntitan MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
+| Syntitan | Data Analytics | `https://mcp.syntitan.ai/mcp` | OAuth2.1 | [Syntitan](https://syntitan.ai) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |


### PR DESCRIPTION
Adds **Syntitan** (Data Analytics) — a remote MCP server.

| Field | Value |
|---|---|
| Name | Syntitan |
| Category | Data Analytics |
| URL | `https://mcp.syntitan.ai/mcp` |
| Auth | OAuth2.1 |
| Maintainer | [Syntitan](https://syntitan.ai) |

AI-Ready Data Platform: diagnose dataset AI-readiness, inspect schemas/columns, and run data quality refinement via natural language. Also on the official MCP Registry as `ai.syntitan/syntitan-mcp`.