### PR TITLE
Add NP Ledger — nonprofit fund accounting remote MCP server (resubmit of #391)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
+| NP Ledger | Accounting | `https://mcp.npledger.com/v1/` | OAuth2.1 | [NP Ledger](https://npledger.com) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |


### PR DESCRIPTION
Adds **NP Ledger**, a remote MCP server for nonprofit fund accounting, alphabetically among the existing entries.

> **Note:** This is a courteous resubmission of #391, which was closed (unmerged) on 2026-06-23 — it looked like part of a backlog cleanup rather than a specific decision, so I'm re-opening in case it was swept up unintentionally. Totally understand if it was intentional; if there's a preferred submission path or anything you'd like changed, just let me know and I'll adjust. Thanks for maintaining this list!

| Field | Value |
|------|-------|
| Name | NP Ledger |
| Category | Accounting |
| URL | `https://mcp.npledger.com/v1/` |
| Authentication | OAuth 2.1 (full Dynamic Client Registration + CIMD — connect with just the URL) |
| Maintainer | [NP Ledger](https://npledger.com) (70Ware LLC) |

### Why it meets the quality bar
- **Official Support** — built and operated by 70Ware LLC, the company behind NP Ledger (production SaaS at https://npledger.com). Same trusted domain in the server URL.
- **Production Ready** — live, hosted on Google Cloud Run; serves real nonprofit customers' books.
- **Security** — OAuth 2.1 with DCR; RFC 9728 Protected Resource Metadata at `https://mcp.npledger.com/.well-known/oauth-protected-resource/v1`; per-tool read/write scopes (`mcp:read`/`mcp:write`); write tools execute only on explicit user consent; tenant-isolated (one connection = one organization). No delete tools exposed.
- **Spec-current** — implements MCP `2025-06-18` (Streamable HTTP), with version negotiation back to `2024-11-05`. Tools carry `title` + `readOnlyHint`/`destructiveHint` annotations.
- **Docs / support** — connector guide: https://npledger.com/docs/integrations/ai-agents/ · support: contact@70ware.com

### Verify the OAuth discovery handshake
```bash
curl -s https://mcp.npledger.com/.well-known/oauth-protected-resource/v1
# -> authorization_servers, resource = https://mcp.npledger.com/v1/, scopes_supported = [mcp:read, mcp:write]
```
