### PR TITLE
Add KaiCalls (AI phone secretary) to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
 | Wolfram | Productivity | `https://agenttools.wolfram.com/mcp` | Open | [Wolfram Research](https://www.wolfram.com/) |
+| KaiCalls | Communication | `https://www.kaicalls.com/api/mcp` | OAuth2.1 | [Meet Kai LLC](https://www.kaicalls.com) |
 
 # Remote MCP Installation Guide
 


### PR DESCRIPTION
Adds **KaiCalls**, an AI phone secretary that handles calls, texts, voicemail, and missed-call follow-up for small businesses. The remote MCP server exposes 18 read tools (calls, transcripts, leads, voicemails, SMS, campaigns, analytics) plus an outbound `make_call` tool.

- **Server URL:** `https://www.kaicalls.com/api/mcp` (Streamable HTTP transport)
- **Authentication:** OAuth 2.1 (PKCE / Dynamic Client Registration, per the MCP spec)
- **Public repo:** https://github.com/cgallic/kaicalls-mcp
- **Maintainer:** [Meet Kai LLC](https://www.kaicalls.com)

It meets the contribution criteria: OAuth 2.0 / production-ready and actively maintained (official, hosted service used in production).

Single-line addition to the server list table.