### PR TITLE
Add Mushi Mushi remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
+| Mushi Mushi | Debugging / Monitoring | `https://api.mushimushi.dev/functions/v1/mcp?features=triage,fixes,inventory,setup,docs` | API Key | [Mushi Mushi](https://github.com/kensaurus/mushi-mushi) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 
 | Neon | Software Development | `https://mcp.neon.tech/mcp` | OAuth2.1 | [Neon](https://neon.tech) |


### PR DESCRIPTION
## Summary
Adds Mushi Mushi hosted Streamable HTTP endpoint to the remote MCP server list.

- **URL:** `https://api.mushimushi.dev/functions/v1/mcp?features=triage,fixes,inventory,setup,docs`
- **Auth:** API key (`MUSHI_API_KEY` + optional `MUSHI_PROJECT_ID`)
- **Docs:** https://docs.mushimushi.dev/quickstart/mcp