### PR TITLE
Add BuildCalc API — vertical construction data remote MCP server (resubmit of #368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
+| BuildCalc API | Specialised Dataset | `https://api.buildcalcapi.dev/mcp` | OAuth2.1 | [BuildCalc API](https://buildcalcapi.dev) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |


### PR DESCRIPTION
Adds **BuildCalc API**, a remote MCP server for vertical construction data, alphabetically between `Box` and `Buildkite`.

> **Note:** This is a courteous resubmission of #368, which was closed (unmerged) on 2026-06-23 — it looked like part of a backlog cleanup rather than a specific decision, so I'm re-opening in case it was swept up unintentionally. Totally understand if it was intentional; if there's a preferred submission path or anything you'd like changed, just let me know and I'll adjust. Thanks for maintaining this list!

| Field | Value |
|------|-------|
| Name | BuildCalc API |
| Category | Specialised Dataset |
| URL | `https://api.buildcalcapi.dev/mcp` |
| Authentication | OAuth 2.1 + PKCE S256 (with DCR stub + CIMD support — connect with just the URL) |
| Maintainer | [BuildCalc API](https://buildcalcapi.dev) (NF Nation LLC) |

### Why it meets the quality bar

- **Official Support** — built and operated by NF Nation LLC. Same trusted domain in the server URL (`api.buildcalcapi.dev`). Public manifests + integration docs at https://github.com/Nasty-Fury/buildcalcapi-mcp-server.
- **Production Ready** — live, hosted on Render (Oregon), 100% uptime over the last two weekly Better Stack reports. Stripe LIVE billing wired (free tier + metered overage). Status page: https://status.buildcalcapi.dev.
- **Security** — OAuth 2.1 with PKCE S256; RFC 8414 Authorization Server Metadata at `https://api.buildcalcapi.dev/.well-known/oauth-authorization-server`; RFC 9728 Protected Resource Metadata at `https://api.buildcalcapi.dev/.well-known/oauth-protected-resource`; HS256 JWT access (1h) + refresh (30d) tokens; all 108 tools are read-only (no write/destructive capabilities exposed via MCP).
- **Spec-current** — implements MCP `2025-03-26` (Streamable HTTP). All 108 tools carry `title` + `readOnlyHint: true` + `destructiveHint: false` + `idempotentHint: true` + `openWorldHint: false` annotations.
- **Already listed on adjacent registries** — Anthropic's official MCP Registry as `dev.buildcalcapi/server` v0.4.2 (published 2026-06-03, status `active`); Smithery as `buildcalcapi/server`. Submitted to Glama queue 2026-06-03 (still pending pickup) — happy to add the Glama badge here once that landing comes through. Open PR on `punkpeye/awesome-mcp-servers` (#7350) waiting on the same Glama listing.
- **Domain** — 81 building-code-grounded calculators (concrete, framing, roofing, HVAC sizing, NEC electrical, IRC stairs, IECC envelope, IPC plumbing), 937 IRC/IBC/NEC/IECC/IPC code sections with per-jurisdiction adoption status, federal cost data (BLS PPI materials + BLS OEWS labor wages + BLS QCEW + Census BPS permits), 51,278 certified product SKUs (ENERGY STAR, ICC-ES ESR, NFRC CPD, EPA WaterSense), and project benchmarks. Every value cited to a US standard or manufacturer source.
- **Docs / support** — landing: https://buildcalcapi.dev · docs: https://docs.buildcalcapi.dev · support: partners@buildcalcapi.dev

### Verify the OAuth discovery handshake

```bash
curl -s https://api.buildcalcapi.dev/.well-known/oauth-protected-resource
# -> resource = https://api.buildcalcapi.dev/mcp
#    authorization_servers = ["https://api.buildcalcapi.dev"]
#    bearer_methods_supported = ["header"]

curl -s https://api.buildcalcapi.dev/.well-known/oauth-authorization-server
# -> issuer = https://api.buildcalcapi.dev
#    authorization_endpoint, token_endpoint, registration_endpoint
#    code_challenge_methods_supported = ["S256"]
#    grant_types_supported = ["authorization_code", "refresh_token"]
```