### PR TITLE
Add Mushi Mushi remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 ## Remote MCP Server List
 
+| Mushi Mushi | Debugging / Monitoring | `https://dxptnwrhwsqckaftyymj.supabase.co/functions/v1/mcp?features=triage,fixes,inventory,setup,docs` | API Key | [Mushi Mushi](https://github.com/kensaurus/mushi-mushi) |
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |


### PR DESCRIPTION
## Summary
Re-submits Mushi Mushi after #428 was closed because the previous URL (`mushimushi.dev`) did not resolve.

## Entry
| Mushi Mushi | Debugging / Monitoring | `https://dxptnwrhwsqckaftyymj.supabase.co/functions/v1/mcp?features=triage,fixes,inventory,setup,docs` | API Key | [Mushi Mushi](https://github.com/kensaurus/mushi-mushi) |

## Verification
- MCP endpoint returns HTTP 200: `https://dxptnwrhwsqckaftyymj.supabase.co/functions/v1/mcp`
- Docs: https://kensaur.us/mushi-mushi/docs/quickstart/mcp
- Hosted OAuth bridge: https://kensaur.us/mushi-mushi/hosted-mcp/

Supersedes closed #428 with a live Supabase-hosted MCP URL.