### PR TITLE
Add Custom Website Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudinary | Asset Management | `https://asset-management.mcp.cloudinary.com/sse` | OAuth2.1 | [Cloudinary](https://cloudinary.com) |
 | Cortex | Internal Developer Portal | `https://mcp.cortex.io/mcp` | API Key | [Cortex](https://cortex.io) |
+| Custom Website Editor | Website Builder | `https://www.elijahdesent.com/api/mcp` | OAuth2.1 | [Pastor Eli](https://www.elijahdesent.com) |
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |


### PR DESCRIPTION
Adds **Custom Website Editor**, a remote MCP server that lets non-technical church pastors manage and edit their professionally-built websites in plain English — updating text, photos, pages, custom domains, hosting, and viewing traffic analytics.

| Field | Value |
|------|------|
| URL | `https://www.elijahdesent.com/api/mcp` |
| Category | Website Builder |
| Authentication | OAuth 2.1 (with dynamic client registration) |
| Transport | Streamable HTTP |
| Maintainer | [Pastor Eli](https://www.elijahdesent.com) |

It's also published in the official [MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=com.elijahdesent/custom-website-editor) as `com.elijahdesent/custom-website-editor`. Production-ready and live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)