### PR TITLE
Add BuyWhere MCP Server — Real-time e-commerce product search

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
+| BuyWhere MCP | E-Commerce | `https://api.buywhere.ai/mcp` | API Key | [BuyWhere](https://buywhere.ai) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |


### PR DESCRIPTION
Add BuyWhere MCP Server to the E-Commerce section.

**Server**: BuyWhere MCP — real-time product search and price comparison across 11M+ products, 200+ retailers.
**URL**: `https://api.buywhere.ai/mcp`
**Auth**: API Key (register at https://api.buywhere.ai/v1/auth/register)
**Tools**: search_products, get_product, compare_products, get_deals, list_categories, find_best_price, find_similar, ingest_products

- [BuyWhere MCP](https://buywhere.ai) - E-commerce product search and price comparison server