### PR TITLE
Add Sofya remote MCP server (Search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
+| Sofya | Search | `https://mcp.sofya.co/mcp` | API Key | [Sofya](https://sofya.co) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |


### PR DESCRIPTION
Adds Sofya, a production hosted remote MCP server, to the Search category.

- URL: https://mcp.sofya.co/mcp (live, streamable HTTP). initialize returns serverInfo name "Sofya" version 1.27.0.
- Auth: API Key (bearer).
- Official server maintained by Sofya. Tools: search (full page web search), fetch (URL/PDF to markdown), extract (structured data), research (cited report).
- Inserted alphabetically in the table.

Disclosure: I am involved with Sofya.