### PR TITLE
Add AgentsCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AgentsCoin | Crypto | `https://agents-coin.com/mcp` | Open | [AgentsCoin](https://agents-coin.com) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
Adds **AgentsCoin** to the Remote MCP Server List under the existing **Crypto** category.

AgentsCoin gives an AI agent its own money on a live EVM chain: create a wallet, get AGENT from the faucet, send, and create/trade tokens. 8 tools: network_info, create_wallet, mine (faucet), balance, send, create_coin, add_liquidity, swap.

- Remote MCP URL: `https://agents-coin.com/mcp` (verified live — responds to `initialize` with serverInfo `agentscoin`)
- Server repo: https://github.com/axiosdevs/agentscoin-mcp (npm: `agentscoin-mcp`, `npx agentscoin-mcp`)
- One-click Claude Desktop extension (.mcpb): https://github.com/axiosdevs/agentscoin-claude-extension
- Site: https://agents-coin.com

**Authentication:** the endpoint is currently **Open** (no auth), consistent with other Open entries already in the list (e.g. AWS Knowledge, Find-A-Domain, LiveScore MCP). Happy to add OAuth 2.1 / API Key if required for inclusion.

Single entry, inserted alphabetically.