### PR TITLE
Add FilingFirehose remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Dialer | Outbound Phone Calls | `https://getdialer.app/sse` | OAuth2.1 | [Dialer](https://getdialer.app) |
 | EAN-Search.org | Product Data | `https://www.ean-search.org/mcp` | OAuth2.1 | [EAN-Search.org](https://www.ean-search.org) |
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
+| FilingFirehose | Market Intelligence | `https://filingfirehose.com/mcp` | Open | [FilingFirehose](https://filingfirehose.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |


### PR DESCRIPTION
Adding the **FilingFirehose** remote MCP server.

| Field | Value |
|---|---|
| URL | `https://filingfirehose.com/mcp` |
| Category | Market Intelligence |
| Auth | Open (free public tier; paid plans use API key) |
| Maintainer | [FilingFirehose](https://filingfirehose.com) |

**What it does:** Exposes parsed US SEC EDGAR filings as MCP tools — 8-K (with body-text classifier that flags suspected misclassifications under Item 8.01 such as cyber language buried under "Other Events"), Schedule 13D/G (with activist filer tagging — Saba, Bulldog, Karpus, Icahn, Elliott, Starboard, Pershing, +14 more), and S-3 / 424B5 (shelf size, ATM-offering detection, sales agent extraction).

**Quality criteria:**
- **Official Support** — Maintained by FilingFirehose
- **Production Ready** — Live and serving traffic; underlying API has been live since April 2026
- **Active Maintenance** — Daily ingestion crons; server version visible at `serverInfo`
- **Security** — Open free tier returns last 72 hours; full archive requires API key
- **Reliability** — Hosted on Fly.io with health checks at `/v1/health`

Verified MCP handshake:
```
$ curl -s -X POST https://filingfirehose.com/mcp     -H "Content-Type: application/json"     -H "Accept: application/json, text/event-stream"     -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
=> serverInfo: {"name":"filingfirehose","version":"1.28.1"}
```

Entry inserted alphabetically between Find-A-Domain and Firefly.