### PR TITLE
Add BuyWhere — cross-border e-commerce product search MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
+| BuyWhere | E-Commerce | `https://mcp.buywhere.ai` | API Key | [BuyWhere](https://buywhere.ai) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |


### PR DESCRIPTION
## What
Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) to the Remote MCP Server List.

## Why
BuyWhere is a remote MCP server for cross-border e-commerce product search and price comparison. It provides:
- **11M+ products** across Singapore, SEA, and US markets
- Real-time pricing, inventory, and deal discovery
- Self-service API key in 3s (no signup required)
- Remote MCP endpoint at https://mcp.buywhere.ai

## Verification
- npm: `@buywhere/mcp-server` — 2K+ weekly downloads
- MCP endpoint: https://mcp.buywhere.ai (HTTP 200)
- Official MCP Registry: `io.github.BuyWhere/buywhere-mcp`
- Install: `npx @buywhere/mcp-server`

Thank you for maintaining this list!