### PR TITLE
Add Public Grants MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Plaid | Payments | `https://api.dashboard.plaid.com/mcp/sse` | OAuth2.1 🔐| [Plaid](https://plaid.com) |
 | Prisma Postgres | Database |  `https://mcp.prisma.io/mcp` | OAuth2.1 | [Prisma Postgres](https://www.prisma.io/docs/postgres/integrations/mcp-server#remote-mcp-server)
 | Port IO | Internal Developer Portal | `https://mcp.port.io/v1` | OAuth2.1 | [Port IO](https://port.io) |
+| Public Grants | Government Funding | `https://grants.mrchief.ai/mcp/` | Open | [PyratzLabs](https://pyratzlabs.com) |
 | Ramp | Payments | `https://ramp-mcp-remote.ramp.com/mcp` | OAuth2.1 | [Ramp](https://ramp.com) |
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |


### PR DESCRIPTION
Adds Public Grants, a remote MCP server / Claude connector that helps French startups find public grants and tax credits (CIR, CII, JEI, Bourse French Tech): it matches a startup profile to eligible schemes and drafts a ready-to-file dossier. Free discovery, flat 49 EUR per dossier.

Endpoint: https://grants.mrchief.ai/mcp/
Site: https://grants.mrchief.ai/
Auth: Open (free discovery, paid drafting)
Maintainer: PyratzLabs (Paris)