### PR TITLE
Add DealerMAX (Italian automotive inventory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
 | Wolfram | Productivity | `https://agenttools.wolfram.com/mcp` | Open | [Wolfram Research](https://www.wolfram.com/) |
+| DealerMAX | Automotive | `https://mcp.dealermax.app/mcp` | Open | [DealerMAX](https://dealermax.app) |
 
 # Remote MCP Installation Guide
 


### PR DESCRIPTION
Adds **DealerMAX** to the Remote MCP Server List.

| Field | Value |
|---|---|
| Name | DealerMAX |
| Category | Automotive |
| URL | `https://mcp.dealermax.app/mcp` (Streamable HTTP) |
| Authentication | Open (keyless, public) |
| Maintainer | [DealerMAX](https://dealermax.app) — official |

**What it does:** a public, keyless MCP server for searching verified Italian car-dealer inventory across the DealerMAX network — used vehicles for sale and long-term rental (NLT) offers.

- **Official & production-ready:** maintained by DealerMAX; also listed in the official MCP registry.
- **Verified live:** responds to `initialize` (protocol `2025-06-18`, server `DealerMax` v1.2.1) with tools/resources/prompts.
- Docs: https://developers.dealermax.app/mcp