### PR TITLE
Add SIXTA Connect (Database, OAuth2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Rube | Other | `https://rube.app/mcp` | Oauth2.1 | [Composio](https://composio.dev) |
 | Scorecard | AI Evaluation | `https://scorecard-mcp.dare-d5b.workers.dev/sse` | OAuth2.1 | [Scorecard](https://scorecard.io) |
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
+| SIXTA Connect | Database | `https://connect.sixta.ai/mcp` | OAuth2.1 | [SIXTA](https://sixta.ai) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |


### PR DESCRIPTION
Adds **SIXTA Connect** to the Database category.

| Field | Value |
|---|---|
| Name | SIXTA Connect |
| Category | Database |
| URL | `https://connect.sixta.ai/mcp` |
| Auth | OAuth 2.1 (DCR + PKCE), per the MCP spec |
| Maintainer | [SIXTA](https://sixta.ai) |

SIXTA Connect is a hosted, read-only remote MCP server giving DBRE-grade SQL analysis for PostgreSQL and MySQL: slow-query diagnosis with self-checked rewrites, migration-safety (lock/algorithm) checks, EXPLAIN-plan reading, deadlock reconstruction, index review, workload/N+1 analysis, and SQL security review. It works from pasted artifacts (no database credentials), and nothing pasted is stored.

**Quality criteria**
- Official support: maintained by SIXTA (the company behind it).
- Production ready: live in production; also listed in the official MCP Registry (`ai.sixta/sixta-connect`).
- Security: OAuth 2.1 with Dynamic Client Registration + PKCE (one-click connect in Cursor / VS Code / Claude); API-key fallback for header-capable clients.

**Example usage** — add the URL as a remote MCP server and sign in once:
```
claude mcp add --transport http sixta https://connect.sixta.ai/mcp
```
Then ask about any SQL artifact (a slow query, a migration, an EXPLAIN plan) and the model calls SIXTA on its own.