### PR TITLE
Add BankBridge — read-only bank access for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |
 | Attio | CRM | `https://mcp.attio.com/mcp` | OAuth2.1 | [Attio](https://attio.com) |
 | AWS Knowledge | Software Development | `https://knowledge-mcp.global.api.aws` | Open | [AWS](https://aws.github.io/) |
+| BankBridge | Finance | `https://bankbridge.money/api/mcp` | OAuth2.1 & API Key | [BankBridge](https://bankbridge.money) |
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |


### PR DESCRIPTION
Adds [BankBridge](https://bankbridge.money) to the Remote MCP Server List.

BankBridge is a hosted MCP server (streamable HTTP, MCP 2025-06-18) that gives AI agents **read-only** access to real bank accounts, transactions, and investment holdings. 12 tools — balances, spending, recurring charges, cashflow, holdings, investment txns. Live-fetched on every call (nothing cached server-side). $5/mo per connected bank.

- Endpoint: `https://bankbridge.money/api/mcp`
- Auth: OAuth 2.1 (DCR + PKCE) or Bearer API key
- Press kit: https://bankbridge.money/press
- Maintained by Great Work LLC
