### PR TITLE
Add okdoc — e-signature & document automation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Netlify | Software Development | `https://netlify-mcp.netlify.app/mcp` | OAuth2.1 | [Netlify](https://netlify.com) |
 | Notion | Project Management | `https://mcp.notion.com/sse` | OAuth2.1 | [Notion](https://notion.so) |
 | Octagon | Market Intelligence | `https://mcp.octagonagents.com/mcp` | OAuth2.1 | [Octagon](https://octagonai.co) |
+| okdoc | Document Management | `https://okdocai.com/api/mcp` | OAuth2.1 | [okdoc](https://okdocai.com/ai) |
 | OneContext | RAG-as-a-Service | `https://rag-mcp-2.whatsmcp.workers.dev/sse` | OAuth2.1 | [OneContext](https://onecontext.ai) |
 | PayPal | Payments | `https://mcp.paypal.com/sse` | OAuth2.1 | [PayPal](https://paypal.com) |
 | Parallel Task MCP | Web Research | `https://task-mcp.parallel.ai/mcp` | OAuth2.1 | [Parallel Web Systems](https://parallel.ai) |


### PR DESCRIPTION
This adds **okdoc** ([okdocai.com](https://okdocai.com)), an official, first-party remote MCP server for e-signature and document automation, running in production at `https://okdocai.com/api/mcp` (Streamable HTTP, OAuth 2.1 with PKCE per the MCP spec). It exposes 38 tools covering creating, sending, tracking and signing documents, AI document generation, contract analysis, payments at signing, bulk send, and analytics. Documentation and setup instructions: https://okdocai.com/ai — maintained by the okdoc team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)