### PR TITLE
Add MailKite — remote MCP for agent email (OAuth 2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
+| MailKite | Communication | `https://mcp.mailkite.dev/mcp` | OAuth2.1 | [MailKite](https://mailkite.dev) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |


### PR DESCRIPTION
Adds **MailKite** to the Remote MCP Server List (Communication), in alphabetical order (between Listenetic and Malware Patrol).

| Field | Value |
|---|---|
| Name | MailKite |
| Category | Communication |
| URL | `https://mcp.mailkite.dev/mcp` |
| Authentication | OAuth 2.0 (dynamic client registration supported) |
| Maintainer | [MailKite](https://mailkite.dev) — official |

**What it does:** give any AI agent its own real email inbox — receive email as structured tool calls and send from a verified (SPF+DKIM) domain. Tools for send, inbound routes, webhooks, domains, templates, and message search. Hosted remote, no local install.

Meets the quality criteria: official/vendor-maintained, production-ready, OAuth 2.0.