### PR TITLE
Add AgentServices — Remote MCP for paid AI agent APIs with x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
-| AIServices | Finance \& Crypto | `https://api.aiservices.to/mcp` | Open / x402 | [vbkotecha](https://github.com/vbkotecha) |
+| AgentServices | Finance & Data APIs | `https://api.aiservices.to/mcp` | API Key | [vbkotecha](https://github.com/vbkotecha) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
@@ -369,3 +369,4 @@ Join the MCP community to stay updated and connect with other developers:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
-| AgentServices | Finance & Data APIs | `https://api.aiservices.to/mcp` | API Key | [vbkotecha](https://github.com/vbkotecha) |
+| AgentServices | Finance & Data APIs | `https://agentservices.to/mcp` | API Key | [vbkotecha](https://github.com/vbkotecha) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AIServices | Finance \& Crypto | `https://api.aiservices.to/mcp` | Open / x402 | [vbkotecha](https://github.com/vbkotecha) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
## AgentServices

AgentServices is a remote MCP server providing paid APIs for AI agents with built-in x402 payment protocol and dispute resolution.

**MCP URL:** `https://agentservices.to/mcp`

**Features:**
- 29 API endpoints (crypto data, DeFi yields, indicators, search, news, social, etc.)
- Built-in x402 micropayments (USDC on Base)
- Dispute resolution for agent commerce (POST /v1/disputes)
- MCP endpoint with 37 MCP tools via SSE transport
- Published in MCP Registry (to.aiservices/aiservices v1.0.0)

**Category:** Finance & Data APIs

**Authentication:** API Key (x402 payment for premium endpoints, free endpoints available)

**Docs:** https://agentservices.to

The server is production-ready, live, and actively maintained.