### PR TITLE
Add ~Alter (identity verification, x402) to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
+| ~Alter | Identity | `https://mcp.truealter.com/api/v1/mcp` | OAuth2.1 / x402 | [true-alter](https://github.com/true-alter) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adds ~Alter, hosted streamable-http MCP for verified human identity, 39 tools (30 free / 9 priced), x402 USDC on Base.