### PR TITLE
Add DuckHub (E-Commerce) remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |
 | Dappier | RAG-as-a-Service | `https://mcp.dappier.com/mcp` | API Key | [Dappier](https://dappier.com/) |
 | Mercado Libre | E-Commerce | `https://mcp.mercadolibre.com/mcp` | API Key | [Mercado Libre MCP Server](https://mcp.mercadolibre.com/) |
+| DuckHub | E-Commerce | `https://mcp.duck-hub.com/mcp` | API Key | [DuckHub](https://duck-hub.com) |
 | Mercado Pago | Payments | `https://mcp.mercadopago.com/mcp` | API Key | [Mercado Pago MCP Server](https://mcp.mercadopago.com/) |
 | SearchAPI | Search | `https://www.searchapi.io/mcp` | API Key | [SearchAPI](https://www.searchapi.io) |
 | Short.io | Link shortener | `https://ai-assistant.short.io/mcp` | API Key | [Short.io](https://short.io) |


### PR DESCRIPTION
Adds DuckHub to the E-Commerce category.

DuckHub is an official, hosted remote MCP server for restaurant menu management. It exposes 39 tools over the DuckHub REST API (menu, categories, modifiers, prices, images, translations, promotions, orders), so agents can build and publish a full menu.

- Name: DuckHub
- - Category: E-Commerce
- - URL: https://mcp.duck-hub.com/mcp
- - Auth: API Key (Bearer dk_live_...)
- - Maintainer: DuckHub (official)
- - Docs: https://docs.duck-hub.com/mcp