### PR TITLE
Add AgentServices — x402 Finance & Data APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
-| AIServices | Finance \& Crypto | `https://api.aiservices.to/mcp` | Open / x402 | [vbkotecha](https://github.com/vbkotecha) |
+| AgentServices | Finance & Data APIs | `https://api.aiservices.to/mcp` | API Key | [vbkotecha](https://github.com/vbkotecha) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
@@ -369,3 +369,4 @@ Join the MCP community to stay updated and connect with other developers:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
-| AgentServices | Finance & Data APIs | `https://api.aiservices.to/mcp` | API Key | [vbkotecha](https://github.com/vbkotecha) |
+| AgentServices | Finance & Data APIs | `https://agentservices.to/mcp` | API Key | [vbkotecha](https://github.com/vbkotecha) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
+| AgentServices | Finance & Data | `https://api.agentservices.to/mcp` | x402 | [AgentServices](https://agentservices.to) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |
@@ -369,4 +370,3 @@ Join the MCP community to stay updated and connect with other developers:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| AIServices | Finance \& Crypto | `https://api.aiservices.to/mcp` | Open / x402 | [vbkotecha](https://github.com/vbkotecha) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
## AgentServices

**URL:** https://agentservices.to
**MCP Server:** `https://api.agentservices.to/mcp`
**Auth:** x402 (cryptomicropayments)

AgentServices provides finance and market data APIs for AI agents, with 54 services across 97 endpoints. 41 endpoints are x402-paid (USDC micropayments on Base).

### Key Features
- 37 MCP tools available via the MCP server
- x402 payment protocol for per-call pricing ($0.01–$0.05 per call)
- Categories: market data, FX rates, crypto prices, portfolio analytics, macro indicators
- On official MCP Registry: `to.agentservices/agentservices` (v5.3.0)
- First x402 payment triggered Jul 13, 2026 — confirmed on Base mainnet

### Verification
- MCP handshake confirmed (protocol 2026-07-28, server v5.3.0)
- Homepage: https://agentservices.to
- API docs: https://agentservices.to/docs
- MCP endpoint: `https://api.agentservices.to/mcp`