### PR TITLE
Add Hooklayer to Remote MCP Server List

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |
 | Hive Intelligence | Crypto | `https://hiveintelligence.xyz/mcp` | OAuth 2.1 | [Hive Intelligence](https://hiveintelligence.xyz/) |
+| Hooklayer | Social Media | `https://hooklayer.dev/api/mcp` | OAuth2.1 / API Key | [Hooklayer](https://hooklayer.dev) |
 | Instant | Software Development | `https://mcp.instantdb.com/mcp` | OAuth | [Instant](https://www.instantdb.com/) |
 | Intercom | Customer Support | `https://mcp.intercom.com/sse` | OAuth2.1 | [Intercom](https://intercom.com) |
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |


### PR DESCRIPTION
Adds Hooklayer — a remote MCP server for viral-content intelligence (TikTok/YouTube hook scoring, virality prediction, trend analysis, viral template search). Remote endpoint: https://hooklayer.dev/api/mcp (streamable-http), OAuth2.1 or API key auth. Listed in the official MCP Registry as io.github.khan-ashifur/hooklayer; also on Smithery, Glama, and PulseMCP. Row placed alphabetically, matching table format.