### PR TITLE
Add Agent Web Search MCP server (DuckDuckGo-based, no API key required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
+| Agent Web Search MCP | Web Search | `https://hermes-api.tiagohanna.com/` | Open / API Key | [Tiago Hanna](https://github.com/tiagohanna123) |
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |


### PR DESCRIPTION
### Summary
Add [Agent Web Search MCP](https://hermes-api.tiagohanna.com/) to the Web Search category.

### Details
- **Name:** Agent Web Search MCP
- **Category:** Web Search
- **URL:** https://hermes-api.tiagohanna.com/
- **Authentication:** Open / API Key
- **Maintainer:** [Tiago Hanna](https://github.com/tiagohanna123)
- **Free tier:** 7 requests/IP/day (no API key)
- **Pro tier:** Unlimited (R$50, via API key)
- **Backend:** DuckDuckGo (no API key required for basic usage)

### Notes
This is a remote MCP server (HTTP/JSON-RPC) — no local setup required. Works as a drop-in web search + URL fetch tool for any MCP client.