### PR TITLE
Add MindDory (language learning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |
+| MindDory | Language Learning | `https://api.minddory.com/v1/brain/mcp` | OAuth2.1 | [MindDory](https://minddory.com) |
 | MorningStar | Data Analysis | `https://mcp.morningstar.com/mcp` | OAuth2.1 | [MorningStar](https://morningstar.com) |
 | monday.com | Productivity | `https://mcp.monday.com/sse` | OAuth2.1 |  [monday MCP](https://github.com/mondaycom/mcp) |
 | mypromind.com | Learning | `https://www.mypromind.com/interface/mcp` | OAuth2.1 |  [mypromind MCP](https://www.mypromind.com) | 


### PR DESCRIPTION
Adds MindDory to the Learning category.

MindDory turns AI chat into vocabulary practice: you capture a word or a grammar mistake while you are talking to Claude, and it becomes a spaced-repetition flashcard you actually review later. The connector also exposes the review queue, so the assistant can quiz what is due.

- Endpoint: `https://api.minddory.com/v1/brain/mcp` (streamable HTTP)
- Auth: OAuth 2.1
- Already published in the official MCP registry as `com.minddory/brain`
- Source and copyable examples: https://github.com/Hyneq00/minddory-mcp

Row added alphabetically between Metro MCP and MorningStar, matching the existing table format.