### PR TITLE
Add Studio99 — Calligraphy Maker (Design, OAuth2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Sentry | Software Development | `https://mcp.sentry.dev/sse` | OAuth2.1 | [Sentry](https://sentry.io) |
 | Stack Overflow | Software Development | `https://mcp.stackoverflow.com` | OAuth2.1 | [StackOverflow](https://stackoverflow.com) |
 | Stripe | Payments | `https://mcp.stripe.com/` | OAuth2.1 & API Key | [Stripe](https://stripe.com) |
+| Studio99 | Design | `https://mcp.studio99.app/api/mcp` | OAuth2.1 | [Studio99](https://studio99.app/calligraphymaker/mcp) |
 | Stytch | Authentication | `http://mcp.stytch.dev/mcp` | OAuth2.1 | [Stytch](https://stytch.com) |
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |


### PR DESCRIPTION
Studio99's Calligraphy Maker generates Hindi, Marathi and Gujarati calligraphy and text art from any MCP client, returning high-resolution PNG plus editable SVG. Powered by the IndiaFont engine (400k+ users).

- Server: https://mcp.studio99.app/api/mcp (Streamable HTTP)
- Auth: OAuth 2.1 with dynamic client registration
- Docs: https://studio99.app/calligraphymaker/mcp
- Official MCP Registry: app.studio99/calligraphy

Inserted alphabetically after Stripe. Maintained by Studio99.