### PR TITLE
Add Lobu remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
+| Lobu | Other | `https://lobu.ai/mcp` | OAuth2.1 | [Lobu](https://github.com/lobu-ai/lobu) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |
 | Listenetic | Productivity | `https://mcp.listenetic.com/v1/mcp` | OAuth2.1 | [Listenetic](https://app.listenetic.com) |
-| Lobu | Other | `https://lobu.ai/mcp` | OAuth2.1 | [Lobu](https://github.com/lobu-ai/lobu) |
+| Lobu | Other | `https://lobu.ai/mcp` | OAuth2.1 | [Lobu](https://lobu.ai/) |
 | Malware Patrol | Threat Intelligence | `https://mcp.malwarepatrol.net/v1` | API Key | [Malware Patrol](https://malwarepatrol.net) |
 | Meta Ads by Pipeboard | Advertising | `https://mcp.pipeboard.co/meta-ads-mcp` | OAuth2.1 | [Pipeboard](https://pipeboard.co) |
 | Metro MCP | Transit | `https://metro-mcp.anuragd.me/sse` | OAuth2.1 | [Anurag](https://metro-mcp.anuragd.me/) |


### PR DESCRIPTION
## Summary

Adds Lobu's official remote MCP server.

Lobu is an Apache-2.0 open-source context and control plane for AI agents. Its hosted MCP endpoint is `https://lobu.ai/mcp` and authentication uses OAuth 2.1.

## Why it fits

- Officially maintained by the Lobu team
- Hosted remote MCP endpoint with OAuth 2.1
- Active open-source repository with current releases
- Shared permission-aware company context, scoped identities, approvals, and audit
- Public source and support at https://github.com/lobu-ai/lobu

Lobu repository: https://github.com/lobu-ai/lobu
Lobu website: https://lobu.ai/
