### PR TITLE
Add BuyWhere remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
-| BuyWhere | E-Commerce | `https://mcp.buywhere.ai/mcp` | OAuth2.1 | [BuyWhere](https://buywhere.ai) |
+| BuyWhere | E-Commerce | `https://api.buywhere.ai/mcp` | API Key | [BuyWhere](https://buywhere.ai) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | BGPT | Scientific Research | `https://bgpt.pro/mcp/sse` | Open / API Key | [BGPT](https://bgpt.pro/mcp) |
 | Box | Document Management | `https://mcp.box.com` | OAuth2.1 🔐| [Box](https://box.com) |
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
+| BuyWhere | E-Commerce | `https://mcp.buywhere.ai/mcp` | OAuth2.1 | [BuyWhere](https://buywhere.ai) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |


### PR DESCRIPTION
## What
Adds [BuyWhere MCP](https://mcp.buywhere.ai/mcp) to the Remote MCP Server List, alphabetically between Buildkite and Canva.

## Entry

| Name | Category | URL | Auth | Maintainer |
|------|----------|-----|------|------------|
| BuyWhere | E-Commerce | `https://mcp.buywhere.ai/mcp` | OAuth2.1 | [BuyWhere](https://buywhere.ai) |

## Per CONTRIBUTING.md
- ✅ Forked the repo
- ✅ Added to appropriate category (E-Commerce)
- ✅ Server name + Category + URL + Authentication (OAuth2.1) + Maintainer all present
- ✅ Example usage: `claude mcp add --transport http buywhere https://mcp.buywhere.ai/mcp --header "Authorization: Bearer $BUYWHERE_TOKEN"`

## About BuyWhere
- v1.1.0 (2026-08-22) — cross-border product catalog for AI agents
- 370M+ live products across SG, MY, VN, TH, PH, US, JP
- 13 tools: search_products, find_best_price, get_deals, get_product, list_categories, etc.
- `deliver_to` shipping signals per result for cross-border price-comparison workflows
- Listed on the official MCP Registry as io.github.BuyWhere/buywhere-mcp@1.1.0 (isLatest: true)
- MIT license