### PR TITLE
Add MachineTranslation.com remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Ferryhopper | Other | `https://mcp.ferryhopper.com/mcp` | Open | [Ferryhopper](https://ferryhopper.github.io/fh-mcp/) |
 | SubwayInfo NYC | Other | `https://subwayinfo.nyc/mcp` | Open | [SubwayInfo NYC](https://subwayinfo.nyc) |
 | Wolfram | Productivity | `https://agenttools.wolfram.com/mcp` | Open | [Wolfram Research](https://www.wolfram.com/) |
+| MachineTranslation.com | Translation | `https://www.machinetranslation.com/mcp` | OAuth2.1 🔐 | [MachineTranslation.com](https://www.machinetranslation.com) |
 
 # Remote MCP Installation Guide
 


### PR DESCRIPTION
Adds MachineTranslation.com, the official remote MCP server from Tomedes.

URL: https://www.machinetranslation.com/mcp (streamable HTTP)
Auth: OAuth 2.1 via browser login — marked with the lock icon as dynamic client registration is not currently supported
Maintainer: Tomedes (official, vendor-maintained)
Repo: https://github.com/Tomedes-Org/machinetranslation.com-mcp
Docs: https://developer.machinetranslation.com/mcp

Tools: smart_translate (runs text through 22 AI translation models and returns the consensus translation) and list_languages.