### PR TITLE
Add Jithox E-Invoice (Compliance) — remote EU e-invoicing readiness, OAuth 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Indeed | Job Board | `https://mcp.indeed.com/claude/mcp` | OAuth2.1 | [Indeed](https://indeed.com) |
 | Invidio | Video Platform | `https://mcp.invideo.io/sse` | OAuth2.1 | [Invidio](https://invideo.io/) |
 | Jam | Software Development | `https://mcp.jam.dev/mcp` | OAuth2.1 | [Jam.dev](https://jam.dev/) |
+| Jithox E-Invoice | Compliance | `https://mcp.jithox.com/mcp` | OAuth2.1 | [Jithox](https://jithox.com) |
 | Kollektiv | Documentation | `https://mcp.thekollektiv.ai/sse` | Oauth2.1 | [Kollektiv](https://github.com/alexander-zuev/kollektiv-mcp) |
 | LiveScore MCP | Sports | `https://livescoremcp.com/sse` | Open | [LiveScore MCP](https://github.com/holoduke/livescore-mcp) |
 | Linear | Project Management | `https://mcp.linear.app/sse` | OAuth2.1 | [Linear](https://linear.app) |


### PR DESCRIPTION
Adds Jithox E-Invoice, a remote MCP server for EU e-invoicing readiness
checks (VAT format, VIES status, Peppol participant lookup, invoice and
readiness validation).

- URL: https://mcp.jithox.com/mcp
- Auth: OAuth 2.1 with PKCE (S256) and dynamic client registration
- Docs: https://jithox.com/mcp/einvoice
- Also listed in the official MCP registry as com.jithox/einvoice-readiness

Read-only: the server validates and reports readiness. It never sends
Peppol invoices and gives no legal or fiscal guarantee; a provider
outage is reported as unavailable rather than as invalid.