### PR TITLE
Add ZenSched remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Simplescraper | Web Scraping | `https://mcp.simplescraper.io/mcp` | OAuth2.1 | [Simplescraper](https://simplescraper.io) |
 | WayStation | Productivity | `https://waystation.ai/mcp` | OAuth2.1 | [WayStation](https://waystation.ai) |
 | Zenable | Security | `https://mcp.zenable.app/` | OAuth2.1 | [Zenable](https://zenable.io) |
+| ZenSched | Other | `https://mcp.zensched.com/mcp` | OAuth2.1 & API Key | [ZenSched](https://www.zensched.com) |
 | Zine | Memory | `https://www.zine.ai/mcp` | OAuth2.1 | [Zine](https://www.zine.ai/) |
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |


### PR DESCRIPTION
Official production remote MCP at https://mcp.zensched.com/mcp, listed in the official MCP registry as com.zensched/zensched. Auth is OAuth 2.1 (Claude Connect) plus Bearer API keys (zsc_), same pattern as Stripe on this list. Docs: https://www.zensched.com/docs/quickstart/ Privacy: https://www.zensched.com/legal/privacy/