### PR TITLE
Add ContextStream remote MCP server (Memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Cloudflare Docs | Documentation | `https://docs.mcp.cloudflare.com/sse` | Open | [Cloudflare](https://cloudflare.com) |
 | Astro Docs | Documentation | `https://mcp.docs.astro.build/mcp` | Open | [Astro](https://astro.build) |
 | Context Awesome | Specialised Dataset | `https://www.context-awesome.com/api/mcp` | Open | [Context Awesome](https://www.context-awesome.com/) |
+| ContextStream | Memory | `https://mcp.contextstream.io/mcp` | OAuth2.1 | [ContextStream](https://contextstream.io) |
 | Resemble AI | Documentation | `https://mcp.resemble.ai/sse` | Open | [Resemble AI](https://resemble.ai) |
 | DeepWiki | RAG-as-a-Service | `https://mcp.deepwiki.com/sse` | Open | [Devin](https://devin.ai/) |
 | Exa Search | Search | `https://mcp.exa.ai/mcp` | Open | [Exa](https://exa.ai) |


### PR DESCRIPTION
## Summary
Adds **ContextStream** to the remote MCP server list under **Memory** (alongside Zine).

ContextStream provides shared project memory across Cursor, Claude Code, Codex, Grok, and other AI coding agents — one query, same memory across tools.

- Website: https://contextstream.io
- Hosted MCP (OAuth 2.1 / Streamable HTTP): `https://mcp.contextstream.io/mcp`
- GitHub: https://github.com/contextstream/mcp-server
- npm: `@contextstream/mcp-server`

## Table row
```markdown
| ContextStream | Memory | `https://mcp.contextstream.io/mcp` | OAuth2.1 | [ContextStream](https://contextstream.io) |
```

Closes #712

## Test plan
- [ ] Confirm ContextStream appears once in the Remote MCP Server List
- [ ] Confirm category is Memory and auth is OAuth2.1
- [ ] Confirm maintainer link points to https://contextstream.io