### PR TITLE
Add DevDome (Web Analytics, API Key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | zip1.io | Link shortener | `https://zip1.io/mcp` | Open | [zip1.io](https://zip1.io) |
 | Telnyx | Communication | `https://api.telnyx.com/v2/mcp` | API Key | [Telnyx](https://telnyx.com) |
 | Dodo Payments | Payments | `https://mcp.dodopayments.com/sse` | API Key | [Dodo Payments](https://dodopayments.com) |
+| DevDome | Web Analytics | `https://analytics.devdome.com/mcp` | API Key | [DevDome](https://devdome.com/docs/mcp/) |
 | Polar Signals | Software Development | `https://api.polarsignals.com/api/mcp/` | API Key | [Polar Signals](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) |
 | Manifold | Forecasting | `https://api.manifold.markets/v0/mcp` | Open | [Manifold](https://manifold.markets) |
 | Javadocs | Software Development | `https://www.javadocs.dev/mcp` | Open | [Javadocs.dev](https://javadocs.dev) |


### PR DESCRIPTION
Adds DevDome, a first-party hosted remote MCP server for website analytics and site health.

- URL: https://analytics.devdome.com/mcp (streamable HTTP)
- Auth: API key (Bearer header, or ?key= for clients that cannot send headers)
- Maintained by DevDome (devdome.com), listed in the official MCP Registry as com.devdome/analytics
- Docs: https://devdome.com/docs/mcp/, repo https://github.com/DevDomeFamily/devdome-mcp