### PR TITLE
Add FindSaunaPlunge (Health & Wellness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Egnyte | Document Management | `https://mcp-server.egnyte.com/sse` | OAuth2.1 | [Egnyte](https://egnyte.com) |
 | Firefly | Productivity | `https://api.fireflies.ai/mcp` | OAuth2.1 | [Firefly](https://fireflies.ai) |
 | Find-A-Domain | Productivity | `https://api.findadomain.dev/mcp` | Open | [Find-A-Domain](https://findadomain.dev) |
+| FindSaunaPlunge | Health & Wellness | `https://findsaunaplunge.com/mcp` | Open | [FindSaunaPlunge](https://findsaunaplunge.com) |
 | GitHub | Software Development | `https://api.githubcopilot.com/mcp` | OAuth2.1 🔐 | [GitHub](https://github.com) |
 | Globalping | Software Development | `https://mcp.globalping.dev/sse` | OAuth2.1 | [Globalping](https://globalping.io/) |
 | Grafbase | Software Development | `https://api.grafbase.com/mcp` | OAuth 2.1 | [Grafbase](https://grafbase.com) |


### PR DESCRIPTION
Adds FindSaunaPlunge, a remote MCP server for US cold plunge, sauna and contrast-therapy venues, to the table under a new "Health & Wellness" category (none of the existing categories fits a venue-lookup server; happy to move it to "Other" if you prefer).

- **Server name:** FindSaunaPlunge
- **Category:** Health & Wellness
- **URL:** `https://findsaunaplunge.com/mcp` (Streamable HTTP, stateless)
- **Authentication:** Open — no key, no OAuth, open CORS
- **Maintainer:** [FindSaunaPlunge](https://findsaunaplunge.com); source and manifest at [github.com/findsaunaplunge/mcp](https://github.com/findsaunaplunge/mcp) (MIT); listed on the official registry as `com.findsaunaplunge/findsaunaplunge` (domain-verified) and on Glama.

**Tools:** `search_venues`, `get_venue`, `list_cities`, `get_city_stats`, `get_data_freshness`. Every venue record carries the date its details were last checked, and every published temperature and price carries its source URL, capture date and quote. Absent fields mean the venue does not publish the detail, never zero.

**Example usage** (plain JSON-RPC, no client needed):

```bash
curl -X POST https://findsaunaplunge.com/mcp \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
       "params":{"name":"search_venues","arguments":{"citySlug":"austin-tx","modality":"cold_plunge","limit":3}}}'
```

In an MCP client: add `https://findsaunaplunge.com/mcp` as a remote server and ask "cold plunge studios in Austin under $40 that publish their water temperature".

**Reliability:** served from Cloudflare's edge in front of a static, versioned data feed; a weekly CI smoke test runs the stdio and HTTP transports against the live endpoint.
