### PR TITLE
Add Antwork to the Social Media category

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
+| Antwork | Social Media | `https://api.antwork.io/mcp` | OAuth2.1 | [Antwork](https://antwork.io) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Name | Category | URL | Authentication | Maintainer |
 |------|----------|-------------|----------------|------------|
 | Airtable | Database | `https://mcp.airtable.com/mcp` | OAuth2.1 | [Airtable](https://airtable.com) |
-| Antwork | Social Media | `https://api.antwork.io/mcp` | OAuth2.1 | [Antwork](https://antwork.io) |
+| Antwork | Social Media | `https://api.antwork.io/mcp` | OAuth2.1 | [Antwork](https://antwork.io?utm_source=awesome-remote-mcp&utm_medium=referral&utm_campaign=directories) |
 | Asana | Project Management | `https://mcp.asana.com/sse` | OAuth2.1 | [Asana](https://asana.com) |
 | Audioscrape | RAG-as-a-Service | `https://mcp.audioscrape.com` | OAuth2.1 | [Audioscrape](https://www.audioscrape.com) |
 | Atlassian | Software Development | `https://mcp.atlassian.com/v1/sse` | OAuth2.1 🔐 | [Atlassian](https://atlassian.com) |


### PR DESCRIPTION
Adds **Antwork** to the Social Media category.

Antwork is a remote MCP server for managing social media from an MCP client. It drafts, schedules and publishes posts to LinkedIn, X, Instagram, TikTok, YouTube, Facebook, Threads and Pinterest, and returns engagement metrics.

| Field | Value |
|---|---|
| Server name | Antwork |
| Category | Social Media |
| URL | `https://api.antwork.io/mcp` |
| Transport | streamable-http |
| Authentication | OAuth 2.1, dynamic client registration + PKCE |
| Maintainer | [Antwork](https://antwork.io) (official) |

Against the quality criteria:

- **Official support**: maintained by the company that operates the service.
- **Security**: OAuth 2.1 per the MCP spec, no API keys or open access.
- **Production ready**: live on a first-party domain and published in the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.antwork/social`.

Example usage, once connected:

> "Draft a post about our launch for my LinkedIn account and schedule it for Tuesday at 9am."

The server also ships MCP-App UI resources, so the calendar and post cards render as interactive panels in clients that support them.

One disambiguation, since it trips up other directories: Antwork (antwork.io) is unrelated to AntWorks (ant.works), the RPA company.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WBSCpT2q1xhCC9JAZHC8F