### PR TITLE
Add Fattly — remote MCP server for AI image, video, ad & voice generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Google Compute Engine	| Developer Tools | `https://compute.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/compute/docs/reference/mcp) |
 | Google GKE | Developer Tools | `https://container.googleapis.com/mcp` | API Key | [Google](https://docs.cloud.google.com/kubernetes-engine/docs/reference/mcp) |
 | Google Maps | Mapping | `https://mapstools.googleapis.com/mcp` | API Key | [Google](https://developers.google.com/maps/ai/grounding-lite/reference/mcp) |
-| HubSpot | CRM | `https://app.hubspot.com/mcp/v1/http` | API Key | [HubSpot](https://hubspot.com) |
+| HubSpot | CRM | `https://app.hubspot.com/mcp/v1/http` | API Key | [HubSpot](https://hubspot.com) | | Fattly | Design | `https://fattly.app/api/mcp` | OAuth2.1 | [Fattly](https://fattly.app) |
 | Needle | RAG-as-a-service | `https://mcp.needle-ai.com/mcp` | API Key | [Needle](https://needle-ai.com) |
 | Zapier | Automation | `https://mcp.zapier.com/api/mcp/mcp` | API Key | [Zapier](https://zapier.com) |
 | Apify | Web Data Extraction Platform | `https://mcp.apify.com` | API Key | [Apify](https://apify.com) |


### PR DESCRIPTION
Adds Fattly, a hosted remote MCP server that generates images, video, ads and voiceovers from 50+ AI models (Nano Banana, Veo, Kling, ElevenLabs and more). OAuth 2.1, production-ready, no API keys to paste.

Hosted MCP: https://fattly.app/api/mcp

🤖 Generated with Claude Code