### PR TITLE
Add ToolYour remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Supabase | Database | `https://mcp.supabase.com/mcp` | OAuth2.1 | [Supabase](https://supabase.com) |
 | Square | Payments | `https://mcp.squareup.com/sse` | OAuth2.1 | [Square](https://square.com) |
 | ThoughtSpot | Data Analytics | `https://agent.thoughtspot.app/mcp` | OAuth2.1 | [ThoughtSpot](https://thoughtspot.com) |
+| ToolYour | Software Development | `https://api.toolyour.com/mcp` | API Key | [ToolYour](https://www.toolyour.com/developers/mcp) |
 | Turkish Airlines | Airlines | `https://mcp.turkishtechlab.com/mcp` | OAuth2.1 | [Turkish Technology](https://mcp.turkishtechlab.com/) |
 | TweetSave | Social Media | `https://mcp.tweetsave.org/sse` | Open | [TweetSave](https://tweetsave.org) |
 | xbird | Social Media | `https://xbirdapi.up.railway.app/mcp` | API Key | [xbird](https://github.com/checkra1neth/xbird-skill) |


### PR DESCRIPTION
## Summary
- Adds ToolYour (https://api.toolyour.com/mcp) under Software Development with API Key auth.
- Official registry: com.toolyour/mcp
- Docs: https://www.toolyour.com/developers/mcp

## Why it fits
- Public HTTPS remote MCP (SSE + streamable-http)
- Documented X-Api-Key auth
- Listed on Official MCP Registry + Smithery