### PR TITLE
Add Carpedia remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is not an exhaustive list of all remote MCP servers. We maintain high stand
 | Buildkite | Software Developmenr | `https://mcp.buildkite.com/mcp` | OAuth2.1 | [Buildkite](https://buildkite.com) |
 | Canva | Design | `https://mcp.canva.com/mcp` | OAuth2.1 | [Canva](https://canva.com) |
 | Carbon Voice | Productivity | `https://mcp.carbonvoice.app` | OAuth2.1 | [Carbon Voice](https://getcarbon.app) |
+| Carpedia | Data Analysis | `https://mcp.carpedia.com.br/mcp` | OAuth2.1 🔐 (PKCE, CIMD) | [Carpedia](https://www.carpedia.com.br/mcp) |
 | Close CRM | CRM | `https://mcp.close.com/mcp` | OAuth2.1 🔐 | [Close](https://close.com/) |
 | Cloudflare Workers | Software Development | `https://bindings.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |
 | Cloudflare Observability | Observability | `https://observability.mcp.cloudflare.com/sse` | OAuth2.1 | [Cloudflare](https://cloudflare.com) |


### PR DESCRIPTION
Adds Carpedia, the official Brazilian vehicle catalog MCP operated by Checklist Soluções em Tecnologia da Informação Ltda.

- Production endpoint: https://mcp.carpedia.com.br/mcp (Streamable HTTP).
- Authentication: OAuth 2.1 with PKCE S256 and Client ID Metadata Documents (CIMD). No Dynamic Client Registration; the lock marker reflects this. CIMD-compatible clients can authorize without manual client registration.
- 16 read-only tools cover specifications, equipment, maintenance schedules, editorial information, registration rankings, FIPE reference prices and estimated ownership costs. No tool creates charges or executes payments.
- A free account enables the tools, subject to usage limits. Data and user experience target Brazil, in Portuguese.

Documentation and examples: https://www.carpedia.com.br/mcp and https://www.carpedia.com.br/desenvolvedores/docs
Support: contato@carpedia.com.br
Privacy: https://www.carpedia.com.br/privacidade

Validation on 2026-09-07: the production OAuth flow completed in Claude and Smithery; Smithery successfully scanned all 16 tools: https://smithery.ai/servers/yago-teixeira/carpedia
Official MCP Registry name: br.com.carpedia/carpedia, version 1.0.0.
Example prompt: "Quais itens de série o Toyota Yaris XS 2025 tem?"

This change adds one table row only.